### PR TITLE
Fix compatability with Python 3.7.

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -101,7 +101,7 @@ class ProofSearchTree(object):
                 next_variable = variable
                 break
         if next_variable is None:
-            raise StopIteration()
+            return
 
         for possible_assignment in self.get_possible_assignments(next_variable, 
             node['variable_assignments'], goal_literals, verbose=verbose):

--- a/rendering/doors.py
+++ b/rendering/doors.py
@@ -118,7 +118,7 @@ def get_token_images(obs_cell):
         yield TOKEN_IMAGES[PLAYER]
     if obs_cell[KEY]:
         yield TOKEN_IMAGES[KEY]
-    raise StopIteration()
+    return
 
 def render(obs, mode='human', close=False):
     layout = build_layout(obs)

--- a/rendering/minecraft.py
+++ b/rendering/minecraft.py
@@ -101,7 +101,7 @@ def get_token_images(obs_cell):
         yield TOKEN_IMAGES[PLANK]
     if obs_cell[AGENT]:
         yield TOKEN_IMAGES[AGENT]
-    raise StopIteration()
+    return
 
 def render(obs, mode='human', close=False):
     layout = build_layout(obs)

--- a/rendering/rearrangement.py
+++ b/rendering/rearrangement.py
@@ -89,7 +89,7 @@ def get_token_images(obs_cell):
         yield TOKEN_IMAGES[ROBOT_HOLDING_BEAR]
     if obs_cell[ROBOT_HOLDING_MONKEY]:
         yield TOKEN_IMAGES[ROBOT_HOLDING_MONKEY]
-    raise StopIteration()
+    return
 
 def render(obs, mode='human', close=False):
     layout = build_layout(obs)


### PR DESCRIPTION
I'm brand new to this project, so apologies if I'm missing something here. With all the dependencies installed, I kept getting this runtime error when running `demo.py`:

```
Obs: {ontable(e:block), ontable(a:block), ontable(d:block), clear(d:block), ontable(b:block), clear(a:block), clear(c:block), clear(e:block), handempty(robot:robot), ontable(f:block), clear(b:block), clear(f:block), ontable(c:block)}
Act: pickup(e:block)
Traceback (most recent call last):
  File "/Users/eli/GitHub/pddlgym/inference.py", line 104, in get_children
    raise StopIteration()
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "demo.py", line 62, in <module>
    run_all()
  File "demo.py", line 57, in run_all
    demo_ff_planning("conditionalblocks", 5, render=render, test=True, verbose=verbose)
  File "demo.py", line 20, in demo_ff_planning
    run_planning_demo(env, 'ff', verbose=verbose)
  File "/Users/eli/GitHub/pddlgym/utils.py", line 89, in run_planning_demo
    obs, reward, done, _ = env.step(action)
  File "/Users/eli/GitHub/pddlgym/utils.py", line 135, in step
    obs, reward, done, debug_info = super().step(action)
  File "/Users/eli/GitHub/pddlgym/pddlgymenv/lib/python3.7/site-packages/gym/core.py", line 229, in step
    return self.env.step(action)
  File "/Users/eli/GitHub/pddlgym/core.py", line 307, in step
    selected_operator, assignment = self._select_operator(action)
  File "/Users/eli/GitHub/pddlgym/core.py", line 270, in _select_operator
    assignments = find_satisfying_assignments(kb, conds)
  File "/Users/eli/GitHub/pddlgym/inference.py", line 10, in find_satisfying_assignments
    max_assignment_count=max_assignment_count, verbose=verbose)
  File "/Users/eli/GitHub/pddlgym/inference.py", line 79, in prove
    for child in self.get_children(node, variables, goal_literals, verbose=verbose):
RuntimeError: generator raised StopIteration
```

After researching, I think that this is because I am using Python 3.7, unless this behavior is expected (I assume that it isn't since this is the demo?)

Previously, 'raise StopIteration()' was an acceptable way to end a generator. However, with Python 3.7, this gets converted into a runtime error (see [PEP 479](https://www.python.org/dev/peps/pep-0479)).

This PR replaces the line that causes the issue, `raise StopIteration()`, with `return`, which ends the generator the same way the previous line did in older versions of Python.

Thanks!!