### PR TITLE
fix: '=' predicate causing TypeError

### DIFF
--- a/pddlgym/structs.py
+++ b/pddlgym/structs.py
@@ -142,7 +142,7 @@ class Predicate(object):
         return variables
 
     def pddl_str(self):
-        if len(self.var_types) > 0:
+        if self.var_types and len(self.var_types) > 0:
             var_str = " " + " ".join(self.pddl_variables())
         else:
             var_str = ""


### PR DESCRIPTION
= predicate in the SnakeEnv causes `TypeError: object of type 'NoneType' has no len()`

Minimal test:

```python
import gym
import pddlgym

if __name__ == '__main__':
  env = gym.make("PDDLEnvSnake-v0")
  env.fix_problem_index(0)
  obs, debug_info = env.reset()  # TODO: make a pull request to properly adhere to gym interface
  action = env.action_space.sample(obs)
```
