### PR TITLE
Fix bugs in _apply_effects and add test for probabilistic domains

### DIFF
--- a/pddlgym/core.py
+++ b/pddlgym/core.py
@@ -266,7 +266,12 @@ def _apply_effects(state, lifted_effects, assignments, get_all_transitions=False
         new_prob_literals = _compute_new_state_from_lifted_effects(new_determinized_lifted_effects, assignments, new_prob_literals)
 
         new_state = state.with_literals(new_prob_literals)
-        states_to_probs[new_state] = total_proba
+        if new_state in states_to_probs:
+            # If there are multiple ways of reaching next state,
+            #   then these probabilities have to be summed
+            states_to_probs[new_state] += total_proba
+        else:
+            states_to_probs[new_state] = total_proba
         states.append(new_state)
     if return_probs:
         return states_to_probs

--- a/pddlgym/core.py
+++ b/pddlgym/core.py
@@ -258,6 +258,8 @@ def _apply_effects(state, lifted_effects, assignments, get_all_transitions=False
     states_to_probs = {}
     for prob_efs_combination in probabilistic_effects_combinations:
         total_proba = np.prod([lit.proba for lit in prob_efs_combination])
+        if total_proba == 0:
+            continue
         new_prob_literals = set(state.literals)
         new_determinized_lifted_effects = determinized_lifted_effects + \
             list(prob_efs_combination)
@@ -268,6 +270,7 @@ def _apply_effects(state, lifted_effects, assignments, get_all_transitions=False
         states.append(new_state)
     if return_probs:
         return states_to_probs
+    # convert list of states to set
     return frozenset(states)
 
 

--- a/pddlgym/tests/pddl/test_probabilistic_domain_alt.pddl
+++ b/pddlgym/tests/pddl/test_probabilistic_domain_alt.pddl
@@ -1,0 +1,24 @@
+; this is a comment
+(define (domain test-probabilistic-domain-alt)
+  (:requirements :typing :probabilistic-effects)
+  (:types type1 type2)
+  (:predicates (pred1 ?x - type1)
+               (pred2 ?x - type2)
+               (pred3 ?x - type1 ?y - type2 ?z - type2)
+               (actionpred ?x - type1)
+  )
+
+  ; (:actions actionpred)
+(and 
+  (:action action1
+   :parameters (?a - type1 ?b - type1 ?c - type2 ?d - type2)
+   :precondition (and (actionpred ?b)
+                      (pred1 ?b)
+                      (pred3 ?a ?c ?d)
+                      (pred2 ?c)
+                      )
+   :effect       (and 
+                      (probabilistic 0.25 (and (pred3 ?b ?d ?c)))
+                      (probabilistic 0.3 (and (not (pred2 ?c)))))
+   )
+)

--- a/pddlgym/tests/pddl/test_probabilistic_domain_alt/test_problem.pddl
+++ b/pddlgym/tests/pddl/test_probabilistic_domain_alt/test_problem.pddl
@@ -1,0 +1,33 @@
+; this is a comment
+(define (problem test-problem)
+  (:domain test-probabilistic-domain-alt)
+  (:objects
+    a1 - type1
+    a2 - type1
+    b1 - type1
+    b2 - type1
+    b3 - type1
+    c1 - type2
+    c2 - type2
+    d1 - type2
+    d2 - type2
+    d3 - type2
+  )
+
+  (:init
+    (pred1 b2)
+    (pred2 c1)
+    (pred3 a1 c1 d1)
+    (pred3 a2 c2 d2)
+    (actionpred a1)
+    (actionpred a2)
+    (actionpred b1)
+    (actionpred b2)
+    (actionpred b3)
+  )
+
+  (:goal (and
+    (pred2 c2)
+    (pred3 b1 c1 d1)
+  ))
+)

--- a/pddlgym/tests/pddl/test_probabilistic_domain_alt_2.pddl
+++ b/pddlgym/tests/pddl/test_probabilistic_domain_alt_2.pddl
@@ -1,0 +1,26 @@
+; this is a comment
+(define (domain test-probabilistic-domain-alt-2)
+  (:requirements :typing :probabilistic-effects)
+  (:types type1 type2)
+  (:predicates (pred1 ?x - type1)
+               (pred2 ?x - type2)
+               (pred3 ?x - type1 ?y - type2 ?z - type2)
+               (actionpred ?x - type1)
+  )
+
+  ; (:actions actionpred)
+(and 
+  (:action action1
+   :parameters (?a - type1 ?b - type1 ?c - type2 ?d - type2)
+   :precondition (and (actionpred ?b)
+                      (pred1 ?b)
+                      (pred3 ?a ?c ?d)
+                      (pred2 ?c)
+                      )
+   :effect       (and 
+                      (probabilistic
+                        0.5  (and (not (pred2 ?c)))
+                        0.4  (and (not (pred1 ?b)))
+                        0.1 (and (pred3 ?b ?d ?c))))
+   )
+)

--- a/pddlgym/tests/pddl/test_probabilistic_domain_alt_2/test_problem.pddl
+++ b/pddlgym/tests/pddl/test_probabilistic_domain_alt_2/test_problem.pddl
@@ -1,0 +1,33 @@
+; this is a comment
+(define (problem test-problem)
+  (:domain test-probabilistic-domain-alt-2)
+  (:objects
+    a1 - type1
+    a2 - type1
+    b1 - type1
+    b2 - type1
+    b3 - type1
+    c1 - type2
+    c2 - type2
+    d1 - type2
+    d2 - type2
+    d3 - type2
+  )
+
+  (:init
+    (pred1 b2)
+    (pred2 c1)
+    (pred3 a1 c1 d1)
+    (pred3 a2 c2 d2)
+    (actionpred a1)
+    (actionpred a2)
+    (actionpred b1)
+    (actionpred b2)
+    (actionpred b3)
+  )
+
+  (:goal (and
+    (pred2 c2)
+    (pred3 b1 c1 d1)
+  ))
+)

--- a/pddlgym/tests/test_pddlenv.py
+++ b/pddlgym/tests/test_pddlenv.py
@@ -179,6 +179,84 @@ def test_get_all_possible_transitions():
 
     print("Test passed.")
 
+def test_get_all_possible_transitions_multiple_effects():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    domain_file = os.path.join(
+        dir_path, 'pddl', 'test_probabilistic_domain_alt.pddl')
+    problem_dir = os.path.join(dir_path, 'pddl', 'test_probabilistic_domain_alt')
+
+    env = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
+                  dynamic_action_space=True)
+
+    obs, _ = env.reset()
+    action = env.action_space.all_ground_literals(obs).pop()
+    transitions = env.get_all_possible_transitions(action)
+
+    transition_list = list(transitions)
+    assert len(transition_list) == 4
+
+    states = set({
+        transition_list[0][0].literals, transition_list[1][0].literals,
+        transition_list[2][0].literals, transition_list[3][0].literals
+    })
+
+    type1 = Type('type1')
+    type2 = Type('type2')
+    pred1 = Predicate('pred1', 1, [type1])
+    pred2 = Predicate('pred2', 1, [type2])
+    pred3 = Predicate('pred3', 3, [type1, type2, type2])
+
+    expected_states = set({
+        frozenset({pred1('b2'), pred3(
+            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}),
+        frozenset({pred1('b2'), pred3(
+            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')}),
+        frozenset({pred1('b2'), pred2('c1'), pred3(
+            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}),
+        frozenset({pred1('b2'), pred2('c1'), pred3(
+            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
+    })
+
+    assert states == expected_states
+
+    # Now test again with return_probs=True.
+    transitions = env.get_all_possible_transitions(action, return_probs=True)
+
+    transition_list = list(transitions)
+    assert len(transition_list) == 4
+    #assert abs(transition_list[0][1]-0.3) < 1e-5 or abs(transition_list[0][1]-0.7) < 1e-5
+    #assert abs(transition_list[1][1]-0.3) < 1e-5 or abs(transition_list[1][1]-0.7) < 1e-5
+    #assert abs(transition_list[0][1]-transition_list[1][1]) > 0.3
+    # state1, state2 = transition_list[0][0][0], transition_list[1][0][0]
+    states_and_probs = {
+        transition_list[0][0][0].literals: transition_list[0][1],
+        transition_list[1][0][0].literals: transition_list[1][1],
+        transition_list[2][0][0].literals: transition_list[2][1],
+        transition_list[3][0][0].literals: transition_list[3][1]
+    }
+
+    type1 = Type('type1')
+    type2 = Type('type2')
+    pred1 = Predicate('pred1', 1, [type1])
+    pred2 = Predicate('pred2', 1, [type2])
+    pred3 = Predicate('pred3', 3, [type1, type2, type2])
+
+    expected_states = {
+        frozenset({pred1('b2'), pred3(
+            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}): 0.225,
+        frozenset({pred1('b2'), pred3(
+            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')}): 0.075,
+        frozenset({pred1('b2'), pred2('c1'), pred3(
+            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}): 0.525,
+        frozenset({pred1('b2'), pred2('c1'), pred3(
+            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')}): 0.175
+    }
+
+    for s, prob in states_and_probs.items():
+        assert s in expected_states
+        assert prob - expected_states[s] < 1e-5
+
+    print("Test passed.")
 
 def test_determinize():
     dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -215,4 +293,5 @@ if __name__ == "__main__":
     test_pddlenv()
     test_pddlenv_hierarchical_types()
     test_get_all_possible_transitions()
+    test_get_all_possible_transitions_multiple_effects()
     test_determinize()

--- a/pddlgym/tests/test_pddlenv.py
+++ b/pddlgym/tests/test_pddlenv.py
@@ -224,10 +224,6 @@ def test_get_all_possible_transitions_multiple_effects():
 
     transition_list = list(transitions)
     assert len(transition_list) == 4
-    #assert abs(transition_list[0][1]-0.3) < 1e-5 or abs(transition_list[0][1]-0.7) < 1e-5
-    #assert abs(transition_list[1][1]-0.3) < 1e-5 or abs(transition_list[1][1]-0.7) < 1e-5
-    #assert abs(transition_list[0][1]-transition_list[1][1]) > 0.3
-    # state1, state2 = transition_list[0][0][0], transition_list[1][0][0]
     states_and_probs = {
         transition_list[0][0][0].literals: transition_list[0][1],
         transition_list[1][0][0].literals: transition_list[1][1],


### PR DESCRIPTION
Hello!

This PR fixes bugs related to correctly calculating states' probabilities, and adds a new test (with a new test domain) for domains with actions that have multiple probabilistic effects.

I'm thinking of adding one more test to test domains with actions that have a single probabilistic effect, but with multiple probabilities (such as `traverse-rocks` in the River domain), too.