### PR TITLE
Add message to InvalidAction exception

### DIFF
--- a/pddlgym/core.py
+++ b/pddlgym/core.py
@@ -79,7 +79,7 @@ def get_successor_state(state, action, domain, raise_error_on_invalid_action=Fal
 
     # No operator was found
     elif raise_error_on_invalid_action:
-        raise InvalidAction()
+        raise InvalidAction(f"called get_successor_state with invalid action '{action}' for given state")
 
     return state
 


### PR DESCRIPTION
As discussed on #62 , adding a message to the `InvalidAction` exception can improve the readability of it. This oneline PR adds it to the single call made to this exception on the codebase.
