### PR TITLE
Various Depreciation/Bug Fixes

### DIFF
--- a/pddlgym/__init__.py
+++ b/pddlgym/__init__.py
@@ -12,7 +12,8 @@ import os
 
 # Save users from having to separately import gym
 def make(*args, **kwargs):
-    return gym.make(*args, **kwargs)
+    # env checker fails since obs is not an numpy array like object
+    return gym.make(*args, disable_env_checker=True, **kwargs)
 
 def register_pddl_env(name, is_test_env, other_args):
     dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "pddl")

--- a/pddlgym/rendering/utils.py
+++ b/pddlgym/rendering/utils.py
@@ -13,12 +13,19 @@ def get_asset_path(asset_name):
     asset_dir_path = os.path.join(dir_path, 'assets')
     return os.path.join(asset_dir_path, asset_name)
 
-def fig2data(fig, dpi=150):
+def fig2data(fig, dpi: int = 150):
     fig.set_dpi(dpi)
     fig.canvas.draw()
-    data = np.fromstring(fig.canvas.tostring_argb(), dtype=np.uint8, sep='')
-    data = data.reshape(fig.canvas.get_width_height()[::-1] + (4,))
+
+    # copy image data from buffer
+    data = np.frombuffer(fig.canvas.tostring_argb(), dtype=np.uint8).copy()
+
+    # get the dpi adjusted figure dimensions
+    width, height = map(int, fig.get_size_inches() * fig.get_dpi())
+    data = data.reshape(height, width, 4)
+    
     data[..., [0, 1, 2, 3]] = data[..., [1, 2, 3, 0]]
+
     return data
 
 def initialize_figure(height, width, fig_scale=1., grid_colors=None):

--- a/pddlgym/rendering/utils.py
+++ b/pddlgym/rendering/utils.py
@@ -73,6 +73,7 @@ def render_from_layout(layout, get_token_images, dpi=150, grid_colors=None):
 
     im = Image.fromarray(im)
     new_width, new_height = (int(im.size[0] * IM_SCALE), int(im.size[1] * IM_SCALE))
+    # TODO : switch resize method to Image.Resampling.LANCZOS when pillow>=10 is supported
     im = im.resize((new_width, new_height), Image.ANTIALIAS)
     im = np.array(im)
 

--- a/pddlgym/rendering/utils.py
+++ b/pddlgym/rendering/utils.py
@@ -73,7 +73,7 @@ def render_from_layout(layout, get_token_images, dpi=150, grid_colors=None):
 
     im = Image.fromarray(im)
     new_width, new_height = (int(im.size[0] * IM_SCALE), int(im.size[1] * IM_SCALE))
-    im = im.resize((new_width, new_height), Image.Resampling.LANCZOS)
+    im = im.resize((new_width, new_height), Image.ANTIALIAS)
     im = np.array(im)
 
     return im

--- a/pddlgym/rendering/utils.py
+++ b/pddlgym/rendering/utils.py
@@ -66,7 +66,7 @@ def render_from_layout(layout, get_token_images, dpi=150, grid_colors=None):
 
     im = Image.fromarray(im)
     new_width, new_height = (int(im.size[0] * IM_SCALE), int(im.size[1] * IM_SCALE))
-    im = im.resize((new_width, new_height), Image.ANTIALIAS)
+    im = im.resize((new_width, new_height), Image.Resampling.LANCZOS)
     im = np.array(im)
 
     return im

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib
-pillow
+pillow>=8,<10
 gym>=0.24.0
 imageio
 networkx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib
 pillow
-gym
+gym>=0.24.0
 imageio
 networkx
 scikit-image


### PR DESCRIPTION
# Overview
The `Hello, PDDLGym` example in the readme was broken on the master branch. This PR introduces some fixes for a couple of bugs, silences OpenAI gym related depreciation notices, and address a pillow depreciation notice.

# Disclaimer
This PR was only tested on my machine with the most recent dependencies. There is a possibility that conforming to the most recent (or relatively recent) dependencies breaks other python environment configurations.

## Python Version
`Python 3.9.13`

## Dependencies
```
cloudpickle==2.1.0
cycler==0.11.0
fonttools==4.33.3
gym==0.24.1
gym-notices==0.0.7
imageio==2.19.3
importlib-metadata==4.11.4
kiwisolver==1.4.3
matplotlib==3.5.2
networkx==2.8.4
numpy==1.22.4
packaging==21.3
Pillow==9.1.1
pyparsing==3.0.9
python-dateutil==2.8.2
PyWavelets==1.3.0
scikit-image==0.19.3
scipy==1.8.1
six==1.16.0
tifffile==2022.5.4
zipp==3.8.0
```