### PR TITLE
Expose submodules and add type annotations

### DIFF
--- a/pddlgym/__init__.py
+++ b/pddlgym/__init__.py
@@ -1,6 +1,9 @@
 """Gym environment registration"""
 
 from . import tests
+from . import core
+from . import structs
+from . import spaces
 
 import matplotlib
 # matplotlib.use("Agg")
@@ -9,13 +12,14 @@ from gym.envs.registration import register
 import gym
 
 import os
+from typing import List
 
 # Save users from having to separately import gym
 def make(*args, **kwargs):
     # env checker fails since obs is not an numpy array like object
     return gym.make(*args, disable_env_checker=True, **kwargs)
 
-def register_pddl_env(name, is_test_env, other_args):
+def register_pddl_env(name: str, is_test_env: bool, other_args: List):
     dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "pddl")
     domain_file = os.path.join(dir_path, "{}.pddl".format(name.lower()))
     gym_name = name.capitalize()

--- a/pddlgym/core.py
+++ b/pddlgym/core.py
@@ -546,7 +546,7 @@ class PDDLEnv(gym.Env):
         if self._render:
             return self._render(self._state.literals, *args, **kwargs)
 
-    def _handle_derived_literals(self, state):
+    def _handle_derived_literals(self, state: State):
         # first remove any old derived literals since they're outdated
         to_remove = set()
         for lit in state.literals:

--- a/pddlgym/parser.py
+++ b/pddlgym/parser.py
@@ -6,7 +6,7 @@ from pddlgym.structs import (Type, Predicate, Literal, LiteralConjunction,
                              DerivedPredicate, NoChange)
 
 import re
-
+from typing import List, Any, Optional, Dict
 
 FAST_DOWNWARD_STR = """
 (define (problem {problem}) (:domain {domain})
@@ -33,7 +33,7 @@ PROBLEM_STR = """
 class Operator:
     """Class to hold an operator.
     """
-    def __init__(self, name, params, preconds, effects):
+    def __init__(self, name: str, params: List[Type], preconds: List[Literal], effects: List[Literal]):
         self.name = name  # string
         self.params = params  # list of structs.Type objects
         self.preconds = preconds  # structs.Literal representing preconditions
@@ -99,6 +99,7 @@ class Operator:
 class PDDLParser:
     """PDDL parsing class.
     """
+    predicates: Dict[str, Predicate]
     def _parse_into_literal(self, string, params, is_effect=False):
         """Parse the given string (representing either preconditions or effects)
         into a literal. Check against params to make sure typing is correct.
@@ -317,13 +318,13 @@ class PDDLDomain:
         # String of domain name.
         self.domain_name = domain_name
         # Dict from type name -> structs.Type object.
-        self.types = types
+        self.types: Dict[str, Type] = types
         # Dict from supertype -> immediate subtypes.
         self.type_hierarchy = type_hierarchy
         # Dict from predicate name -> structs.Predicate object.
-        self.predicates = predicates
+        self.predicates: Dict[str, Predicate] = predicates
         # Dict from operator name -> Operator object (class defined above).
-        self.operators = operators
+        self.operators: Dict[str, Operator] = operators
         # Action predicate names (not part of standard PDDL)
         self.actions = actions
         # Constant objects, shared across problems

--- a/pddlgym/spaces.py
+++ b/pddlgym/spaces.py
@@ -4,8 +4,8 @@ Unlike typical spaces, Literal spaces may change with
 each episode, since objects, and therefore possible
 groundings, may change with each new PDDL problem.
 """
-from pddlgym.structs import LiteralConjunction, Literal, ground_literal
-from pddlgym.parser import PDDLProblemParser
+from pddlgym.structs import LiteralConjunction, Literal, ground_literal, Predicate, State
+from pddlgym.parser import PDDLProblemParser, PDDLDomain
 from pddlgym.downward_translate.instantiate import explore as downward_explore
 from pddlgym.downward_translate.pddl_parser import open as downward_open
 from pddlgym.utils import nostdout
@@ -15,14 +15,15 @@ from collections import defaultdict
 import os
 import tempfile
 import itertools
+from typing import Set, Collection, Callable
 
 TMP_PDDL_DIR = "/dev/shm" if os.path.exists("/dev/shm") else None
 
 
 class LiteralSpace(Space):
 
-    def __init__(self, predicates,
-                 lit_valid_test=lambda state,lit: True,
+    def __init__(self, predicates: Collection[Predicate],
+                 lit_valid_test: Callable[[State, Literal], bool] =lambda state,lit: True,
                  type_hierarchy=None,
                  type_to_parent_types=None):
         self.predicates = sorted(predicates)
@@ -33,10 +34,10 @@ class LiteralSpace(Space):
         self._type_to_parent_types = type_to_parent_types
         super().__init__()
 
-    def reset_initial_state(self, initial_state):
+    def reset_initial_state(self, initial_state: State):
         self._objects = None
 
-    def _update_objects_from_state(self, state):
+    def _update_objects_from_state(self, state: State):
         """Given a state, extract the objects and if they have changed, 
         recompute all ground literals
         """
@@ -58,7 +59,7 @@ class LiteralSpace(Space):
         self._objects = state.objects
         self._all_ground_literals = sorted(self._compute_all_ground_literals(state))
 
-    def sample_literal(self, state):
+    def sample_literal(self, state: State) -> Literal:
         while True:
             num_lits = len(self._all_ground_literals)
             idx = self.np_random.choice(num_lits)
@@ -67,19 +68,19 @@ class LiteralSpace(Space):
                 break
         return lit  
 
-    def sample(self, state):
+    def sample(self, state: State) -> Literal:
         self._update_objects_from_state(state)
         return self.sample_literal(state)
 
-    def all_ground_literals(self, state, valid_only=True):
+    def all_ground_literals(self, state: State, valid_only: bool=True) -> set[Literal]:
         self._update_objects_from_state(state)
         if not valid_only:
             return set(self._all_ground_literals)
         return set(l for l in self._all_ground_literals \
                    if self._lit_valid_test(state, l))
 
-    def _compute_all_ground_literals(self, state):
-        all_ground_literals = set()
+    def _compute_all_ground_literals(self, state: State) -> set[Literal]:
+        all_ground_literals: Set[Literal] = set()
         for predicate in self.predicates:
             choices = [self._type_to_objs[vt] for vt in predicate.var_types]
             for choice in itertools.product(*choices):
@@ -95,7 +96,7 @@ class LiteralActionSpace(LiteralSpace):
 
     For now, assumes operators_as_actions.
     """
-    def __init__(self, domain, predicates,
+    def __init__(self, domain: PDDLDomain, predicates: Collection[Predicate],
                  type_hierarchy=None, type_to_parent_types=None):
         self.domain = domain
         self._initial_state = None
@@ -116,11 +117,11 @@ class LiteralActionSpace(LiteralSpace):
             type_hierarchy=type_hierarchy,
             type_to_parent_types=type_to_parent_types)
 
-    def reset_initial_state(self, initial_state):
+    def reset_initial_state(self, initial_state: State) -> None:
         super().reset_initial_state(initial_state)
         self._initial_state = initial_state
 
-    def _update_objects_from_state(self, state):
+    def _update_objects_from_state(self, state: State) -> None:
         # Check whether the objects have changed
         # If so, we need to recompute things
         if state.objects == self._objects:
@@ -148,18 +149,18 @@ class LiteralActionSpace(LiteralSpace):
             self._ground_action_to_pos_preconds[ground_action] = pos_preconds
             self._ground_action_to_neg_preconds[ground_action] = neg_preconds
 
-    def sample_literal(self, state):
+    def sample_literal(self, state: State) -> Literal:
         valid_literals = self.all_ground_literals(state)
         valid_literals = list(sorted(valid_literals))
         return valid_literals[self.np_random.choice(len(valid_literals))]
 
-    def sample(self, state):
+    def sample(self, state: State) -> Literal:
         return self.sample_literal(state)
 
-    def all_ground_literals(self, state, valid_only=True):
+    def all_ground_literals(self, state: State, valid_only: bool=True) -> set[Literal]:
         self._update_objects_from_state(state)
         assert valid_only, "The point of this class is to avoid the cross product!"
-        valid_literals = set()
+        valid_literals: Set[Literal] = set()
         for ground_action in self._all_ground_literals:
             pos_preconds = self._ground_action_to_pos_preconds[ground_action]
             if not pos_preconds.issubset(state.literals):
@@ -170,7 +171,7 @@ class LiteralActionSpace(LiteralSpace):
             valid_literals.add(ground_action)
         return valid_literals
 
-    def _compute_all_ground_literals(self, state):
+    def _compute_all_ground_literals(self, state: State) -> set[Literal]:
         """Call FastDownward's instantiator.
         """
         # Generate temporary files to hand over to instantiator.
@@ -193,7 +194,7 @@ class LiteralActionSpace(LiteralSpace):
             _, _, actions, _, _ = downward_explore(task)
         # Post-process to our representation.
         obj_name_to_obj = {obj.name: obj for obj in state.objects}
-        all_ground_literals = set()
+        all_ground_literals: Set[Literal] = set()
         for action in actions:
             name = action.name.strip().strip("()").split()
             pred_name, obj_names = name[0], name[1:]

--- a/pddlgym/structs.py
+++ b/pddlgym/structs.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 """Python classes for common PDDL structures"""
 from collections import namedtuple
 import itertools
 import numpy as np
+
+from typing import NamedTuple, FrozenSet, Collection, Any
 
 
 ### PDDL Types, Objects, Variables ###
@@ -475,24 +479,32 @@ class ProbabilisticEffect:
 ### States ###
 
 # A State is a frozenset of ground literals and a frozenset of objects
-class State(namedtuple("State", ["literals", "objects", "goal"])):
+# class State(namedtuple("State", ["literals", "objects", "goal"])):
+class State(NamedTuple):
+    literals: FrozenSet[Literal]
+    objects: FrozenSet[TypedEntity]
+    goal: Any
+    # MF: We can't easily type goal yet bc it can be a Literal, LiteralConjunction, etc
+    # Ideally we'd make a parent class for all of those.
+
+
     __slots__ = ()
 
-    def with_literals(self, literals):
+    def with_literals(self, literals: Collection[Literal]) -> State:
         """
         Return a new state that has the same objects and goal as the given one,
         but has the given set of literals instead of state.literals.
         """
         return self._replace(literals=frozenset(literals))
 
-    def with_objects(self, objects):
+    def with_objects(self, objects: Collection[TypedEntity]) -> State:
         """
         Return a new state that has the same literals and goal as the given one,
         but has the given set of objects instead of state.objects.
         """
         return self._replace(objects=frozenset(objects))
 
-    def with_goal(self, goal):
+    def with_goal(self, goal) -> State:
         """
         Return a new state that has the same literals and objects as the given
         one, but has the given goal instead of state.goal.

--- a/pddlgym/structs.py
+++ b/pddlgym/structs.py
@@ -488,8 +488,6 @@ class State(NamedTuple):
     # Ideally we'd make a parent class for all of those.
 
 
-    __slots__ = ()
-
     def with_literals(self, literals: Collection[Literal]) -> State:
         """
         Return a new state that has the same objects and goal as the given one,

--- a/pddlgym/tests/run_all_tests.py
+++ b/pddlgym/tests/run_all_tests.py
@@ -1,0 +1,11 @@
+# import os
+
+
+
+# if __name__ == "__main__":
+
+#     testdir = os.path.dirname(__file__)
+#     filenames = os.listdir()
+#     for nm in filenames:
+#         pth = os.path.join(testdir, nm)
+#         if os.path.isfile(pth):

--- a/pddlgym/tests/test_inference.py
+++ b/pddlgym/tests/test_inference.py
@@ -1,112 +1,109 @@
 from pddlgym.inference import find_satisfying_assignments
 from pddlgym.structs import Predicate, Type, Not
 
+import unittest
 
-def test_prover():
-    TType = Type('t')
-    atom0, atom1, atom2 = TType('atom0'), TType('atom1'), TType('atom2')
-    var0, var1, var2, var3 = TType('Var0'), TType('Var1'), TType('Var2'), TType('Var3')
+class TestProver(unittest.TestCase):
+    def test_prover(self):
+        TType = Type('t')
+        atom0, atom1, atom2 = TType('atom0'), TType('atom1'), TType('atom2')
+        var0, var1, var2, var3 = TType('Var0'), TType('Var1'), TType('Var2'), TType('Var3')
 
-    # Single predicate single arity test
-    predicate0 = Predicate('Predicate0', 1, [TType])
-    predicate1 = Predicate('Predicate1', 2, [TType, TType])
-    predicate2 = Predicate('Predicate2', 1, [TType])
+        # Single predicate single arity test
+        predicate0 = Predicate('Predicate0', 1, [TType])
+        predicate1 = Predicate('Predicate1', 2, [TType, TType])
+        predicate2 = Predicate('Predicate2', 1, [TType])
 
-    kb0 = [predicate0(atom0)]
-    assignments = find_satisfying_assignments(kb0, [predicate0(var0)])
-    assert len(assignments) == 1
-    assert len(assignments[0]) == 1
-    assert assignments[0][var0] == atom0
+        kb0 = [predicate0(atom0)]
+        assignments = find_satisfying_assignments(kb0, [predicate0(var0)])
+        assert len(assignments) == 1
+        assert len(assignments[0]) == 1
+        assert assignments[0][var0] == atom0
 
-    assignments = find_satisfying_assignments(kb0, [predicate0(var0), predicate0(var1)])
-    assert len(assignments) == 1
+        assignments = find_satisfying_assignments(kb0, [predicate0(var0), predicate0(var1)])
+        assert len(assignments) == 1
 
-    kb1 = [predicate0(atom0), predicate0(atom1)]
+        kb1 = [predicate0(atom0), predicate0(atom1)]
 
-    assignments = find_satisfying_assignments(kb1, [predicate0(var0)])
-    assert len(assignments) == 2
+        assignments = find_satisfying_assignments(kb1, [predicate0(var0)])
+        assert len(assignments) == 2
 
-    assignments = find_satisfying_assignments(kb1, [predicate0(var0), predicate0(var1)])
-    assert len(assignments) == 2
+        assignments = find_satisfying_assignments(kb1, [predicate0(var0), predicate0(var1)])
+        assert len(assignments) == 2
 
-    assignments = find_satisfying_assignments(kb1, [predicate0(var0), predicate0(var1), predicate0(var2)])
-    assert len(assignments) == 2
+        assignments = find_satisfying_assignments(kb1, [predicate0(var0), predicate0(var1), predicate0(var2)])
+        assert len(assignments) == 2
 
-    kb2 = [predicate0(atom0), predicate0(atom1), predicate0(atom2)]
+        kb2 = [predicate0(atom0), predicate0(atom1), predicate0(atom2)]
 
-    assignments = find_satisfying_assignments(kb2, [predicate0(var0)])
-    assert len(assignments) == 2
+        assignments = find_satisfying_assignments(kb2, [predicate0(var0)])
+        assert len(assignments) == 2
 
-    assignments = find_satisfying_assignments(kb2, [predicate0(var0), predicate0(var1)])
-    assert len(assignments) == 2
+        assignments = find_satisfying_assignments(kb2, [predicate0(var0), predicate0(var1)])
+        assert len(assignments) == 2
 
-    assignments = find_satisfying_assignments(kb2, [predicate0(var0), predicate0(var1), predicate0(var2)])
-    assert len(assignments) == 2
+        assignments = find_satisfying_assignments(kb2, [predicate0(var0), predicate0(var1), predicate0(var2)])
+        assert len(assignments) == 2
 
-    # Single predicate multiple arity test
-    kb3 = [predicate1(atom0, atom1), predicate1(atom1, atom2)]
+        # Single predicate multiple arity test
+        kb3 = [predicate1(atom0, atom1), predicate1(atom1, atom2)]
 
-    assignments = find_satisfying_assignments(kb3, [predicate1(var0, var1)])
-    assert len(assignments) == 2
+        assignments = find_satisfying_assignments(kb3, [predicate1(var0, var1)])
+        assert len(assignments) == 2
 
-    assignments = find_satisfying_assignments(kb3, [predicate1(var0, var1), predicate1(var1, var2)])
-    assert len(assignments) == 1
+        assignments = find_satisfying_assignments(kb3, [predicate1(var0, var1), predicate1(var1, var2)])
+        assert len(assignments) == 1
 
-    assignments = find_satisfying_assignments(kb3, [predicate1(var0, var1), predicate1(var1, var0)])
-    assert len(assignments) == 0
+        assignments = find_satisfying_assignments(kb3, [predicate1(var0, var1), predicate1(var1, var0)])
+        assert len(assignments) == 0
 
-    assignments = find_satisfying_assignments(kb3, [predicate1(var0, var1), predicate1(var2, var3)])
-    assert len(assignments) == 2
+        assignments = find_satisfying_assignments(kb3, [predicate1(var0, var1), predicate1(var2, var3)])
+        assert len(assignments) == 2
 
-    ## Multiple predicate multiple arity test
-    kb4 = [predicate0(atom2), predicate1(atom0, atom1), predicate1(atom1, atom2)]
+        ## Multiple predicate multiple arity test
+        kb4 = [predicate0(atom2), predicate1(atom0, atom1), predicate1(atom1, atom2)]
 
-    assignments = find_satisfying_assignments(kb4, [predicate1(var0, var1), predicate0(var1), predicate0(var0)])
-    assert len(assignments) == 0
+        assignments = find_satisfying_assignments(kb4, [predicate1(var0, var1), predicate0(var1), predicate0(var0)])
+        assert len(assignments) == 0
 
-    ## Tricky case!
-    kb6 = [predicate0(atom0), predicate2(atom1), predicate1(atom0, atom2), predicate1(atom2, atom1)]
+        ## Tricky case!
+        kb6 = [predicate0(atom0), predicate2(atom1), predicate1(atom0, atom2), predicate1(atom2, atom1)]
 
-    assignments = find_satisfying_assignments(kb6, [predicate0(var0), predicate2(var1), predicate1(var0, var1)])
-    assert len(assignments) == 0
+        assignments = find_satisfying_assignments(kb6, [predicate0(var0), predicate2(var1), predicate1(var0, var1)])
+        assert len(assignments) == 0
 
-    print("Pass.")
+class TestNegativePreconditions(unittest.TestCase):
+    def test_negative_preconditions(self):
+        MoveableType = Type('moveable')
+        Holding = Predicate('Holding', 1, var_types=[MoveableType])
+        IsPawn = Predicate('IsPawn', 1, var_types=[MoveableType])
+        PutOn = Predicate('PutOn', 1, var_types=[MoveableType])
+        On = Predicate('On', 2, var_types=[MoveableType, MoveableType])
 
-def test_negative_preconditions():
-    MoveableType = Type('moveable')
-    Holding = Predicate('Holding', 1, var_types=[MoveableType])
-    IsPawn = Predicate('IsPawn', 1, var_types=[MoveableType])
-    PutOn = Predicate('PutOn', 1, var_types=[MoveableType])
-    On = Predicate('On', 2, var_types=[MoveableType, MoveableType])
+        # ?x0 must bind to o0 and ?x1 must bind to o1, so ?x2 must bind to o2
+        conds = [ PutOn("?x0"), Holding("?x1"), IsPawn("?x2"), Not(On("?x2", "?x0")) ]
+        kb = { PutOn('o0'), IsPawn('o0'), IsPawn('o1'), IsPawn('o2'), Holding('o1'), }
+        assignments = find_satisfying_assignments(kb, conds, allow_redundant_variables=False)
+        assert len(assignments) == 1
 
-    # ?x0 must bind to o0 and ?x1 must bind to o1, so ?x2 must bind to o2
-    conds = [ PutOn("?x0"), Holding("?x1"), IsPawn("?x2"), Not(On("?x2", "?x0")) ]
-    kb = { PutOn('o0'), IsPawn('o0'), IsPawn('o1'), IsPawn('o2'), Holding('o1'), }
-    assignments = find_satisfying_assignments(kb, conds, allow_redundant_variables=False)
-    assert len(assignments) == 1
+        # should be the same, even though IsPawn("?x2") is removed
+        conds = [ PutOn("?x0"), Holding("?x1"), Not(On("?x2", "?x0")) ]
+        kb = { PutOn('o0'), IsPawn('o0'), IsPawn('o1'), IsPawn('o2'), Holding('o1'), }
+        assignments = find_satisfying_assignments(kb, conds, allow_redundant_variables=False)
+        assert len(assignments) == 1
 
-    # should be the same, even though IsPawn("?x2") is removed
-    conds = [ PutOn("?x0"), Holding("?x1"), Not(On("?x2", "?x0")) ]
-    kb = { PutOn('o0'), IsPawn('o0'), IsPawn('o1'), IsPawn('o2'), Holding('o1'), }
-    assignments = find_satisfying_assignments(kb, conds, allow_redundant_variables=False)
-    assert len(assignments) == 1
+class TestZeroArityNegativePreconditions(unittest.TestCase):
 
-    print("Pass.")
+    def test_zero_arity_negative_preconditions(self):
+        MoveableType = Type('moveable')
+        Holding = Predicate('Holding', 1, var_types=[MoveableType])
+        HandEmpty = Predicate('HandEmpty', 0, var_types=[])
 
-def test_zero_arity_negative_preconditions():
-    MoveableType = Type('moveable')
-    Holding = Predicate('Holding', 1, var_types=[MoveableType])
-    HandEmpty = Predicate('HandEmpty', 0, var_types=[])
+        conds = [ Holding("?x1"), Not(HandEmpty()) ]
+        kb = { Holding("a"), HandEmpty() }
+        assignments = find_satisfying_assignments(kb, conds, allow_redundant_variables=False)
+        assert len(assignments) == 0
 
-    conds = [ Holding("?x1"), Not(HandEmpty()) ]
-    kb = { Holding("a"), HandEmpty() }
-    assignments = find_satisfying_assignments(kb, conds, allow_redundant_variables=False)
-    assert len(assignments) == 0
-
-    print("Pass.")
 
 if __name__ == "__main__":
-    test_prover()
-    test_negative_preconditions()
-    test_zero_arity_negative_preconditions()
-
+    unittest.main()

--- a/pddlgym/tests/test_parser.py
+++ b/pddlgym/tests/test_parser.py
@@ -2,103 +2,104 @@ from pddlgym.parser import PDDLDomainParser, PDDLProblemParser
 from pddlgym.structs import Predicate, Literal, Type, Not, Anti, LiteralConjunction
 
 import os
+import unittest
 
-def test_parser():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    domain_file = os.path.join(dir_path, 'pddl', 'test_domain.pddl')
-    problem_file = os.path.join(dir_path, 'pddl', 'test_domain', 'test_problem.pddl')
-    domain = PDDLDomainParser(domain_file)
-    problem = PDDLProblemParser(problem_file, domain.domain_name, domain.types,
-        domain.predicates, domain.actions)
+class TestParser(unittest.TestCase):
+    def test_parser(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        domain_file = os.path.join(dir_path, 'pddl', 'test_domain.pddl')
+        problem_file = os.path.join(dir_path, 'pddl', 'test_domain', 'test_problem.pddl')
+        domain = PDDLDomainParser(domain_file)
+        problem = PDDLProblemParser(problem_file, domain.domain_name, domain.types,
+            domain.predicates, domain.actions)
 
-    ## Check domain
-    type1 = Type('type1')
-    type2 = Type('type2')
+        ## Check domain
+        type1 = Type('type1')
+        type2 = Type('type2')
 
-    # Action predicates
-    action_pred = Predicate('actionpred', 1, [type1])
+        # Action predicates
+        action_pred = Predicate('actionpred', 1, [type1])
 
-    # Predicates
-    pred1 = Predicate('pred1', 1, [type1])
-    pred2 = Predicate('pred2', 1, [type2])
-    pred3 = Predicate('pred3', 3, [type1, type2, type2])
-    assert set(domain.predicates.values()) == { pred1, pred2, pred3, action_pred }
-    assert domain.actions == { action_pred.name }
+        # Predicates
+        pred1 = Predicate('pred1', 1, [type1])
+        pred2 = Predicate('pred2', 1, [type2])
+        pred3 = Predicate('pred3', 3, [type1, type2, type2])
+        assert set(domain.predicates.values()) == { pred1, pred2, pred3, action_pred }
+        assert domain.actions == { action_pred.name }
 
-    # Operators
-    assert len(domain.operators) == 1
-    operator1 = Predicate('action1', 4, [type1, type1, type2, type2])
-    assert operator1 in domain.operators
+        # Operators
+        assert len(domain.operators) == 1
+        operator1 = Predicate('action1', 4, [type1, type1, type2, type2])
+        assert operator1 in domain.operators
 
-    operator = domain.operators[operator1]
-    # Operator parameters
-    assert len(operator.params) == 4
-    assert operator.params[0] == type1('?a')
-    assert operator.params[1] == type1('?b')
-    assert operator.params[2] == type2('?c')
-    assert operator.params[3] == type2('?d')
+        operator = domain.operators[operator1]
+        # Operator parameters
+        assert len(operator.params) == 4
+        assert operator.params[0] == type1('?a')
+        assert operator.params[1] == type1('?b')
+        assert operator.params[2] == type2('?c')
+        assert operator.params[3] == type2('?d')
 
-    # Operator preconditions (set of Literals)
-    assert len(operator.preconds.literals) == 4
-    assert set(operator.preconds.literals) == { action_pred('?b'), pred1('?b'), 
-        pred3('?a', '?c', '?d'), pred2('?c') }
+        # Operator preconditions (set of Literals)
+        assert len(operator.preconds.literals) == 4
+        assert set(operator.preconds.literals) == { action_pred('?b'), pred1('?b'), 
+            pred3('?a', '?c', '?d'), pred2('?c') }
 
-    # Operator effects (set of Literals)
-    assert len(operator.effects.literals) == 2
-    assert set(operator.effects.literals) == { Anti(pred2('?c')), 
-        pred3('?b', '?d', '?c')}
+        # Operator effects (set of Literals)
+        assert len(operator.effects.literals) == 2
+        assert set(operator.effects.literals) == { Anti(pred2('?c')), 
+            pred3('?b', '?d', '?c')}
 
-    ## Check problem
+        ## Check problem
 
-    # Objects
-    assert set(problem.objects) == {type1('a1'), type1('a2'), type1('b1'),
-        type1('b2'), type1('b3'), type2('c1'), type2('c2'), type2('d1'), 
-        type2('d2'), type2('d3')}
+        # Objects
+        assert set(problem.objects) == {type1('a1'), type1('a2'), type1('b1'),
+            type1('b2'), type1('b3'), type2('c1'), type2('c2'), type2('d1'), 
+            type2('d2'), type2('d3')}
 
-    # Goal
-    assert isinstance(problem.goal, LiteralConjunction)
-    assert set(problem.goal.literals) == {pred2('c2'), pred3('b1', 'c1', 'd1')}
+        # Goal
+        assert isinstance(problem.goal, LiteralConjunction)
+        assert set(problem.goal.literals) == {pred2('c2'), pred3('b1', 'c1', 'd1')}
 
-    # Init
-    assert problem.initial_state == frozenset({ pred1('b2'), pred2('c1'),
-        pred3('a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2') })
+        # Init
+        assert problem.initial_state == frozenset({ pred1('b2'), pred2('c1'),
+            pred3('a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2') })
 
-    print("Test passed.")
 
-def test_hierarchical_types():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    domain_file = os.path.join(dir_path, 'pddl', 'hierarchical_type_test_domain.pddl')
-    problem_file = os.path.join(dir_path, 'pddl', 'hierarchical_type_test_domain', 
-        'hierarchical_type_test_problem.pddl')
-    domain = PDDLDomainParser(domain_file)
-    problem = PDDLProblemParser(problem_file, domain.domain_name, domain.types,
-        domain.predicates, domain.actions)
+class TestHierarchicalTypes(unittest.TestCase):
+    def test_hierarchical_types(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        domain_file = os.path.join(dir_path, 'pddl', 'hierarchical_type_test_domain.pddl')
+        problem_file = os.path.join(dir_path, 'pddl', 'hierarchical_type_test_domain', 
+            'hierarchical_type_test_problem.pddl')
+        domain = PDDLDomainParser(domain_file)
+        problem = PDDLProblemParser(problem_file, domain.domain_name, domain.types,
+            domain.predicates, domain.actions)
 
-    assert set(domain.types.keys()) == {Type("dog"), Type("cat"), Type("animal"), 
-        Type("block"), Type("cylinder"), Type("jindo"), Type("corgi"), 
-        Type("object"), Type("entity")}
+        assert set(domain.types.keys()) == {Type("dog"), Type("cat"), Type("animal"), 
+            Type("block"), Type("cylinder"), Type("jindo"), Type("corgi"), 
+            Type("object"), Type("entity")}
 
-    assert domain.type_hierarchy == {
-        Type("animal") : { Type("dog"), Type("cat") },
-        Type("dog") : { Type("jindo"), Type("corgi") },
-        Type("object") : { Type("block"), Type("cylinder") },
-        Type("entity") : { Type("object"), Type("animal") },
-    }
+        assert domain.type_hierarchy == {
+            Type("animal") : { Type("dog"), Type("cat") },
+            Type("dog") : { Type("jindo"), Type("corgi") },
+            Type("object") : { Type("block"), Type("cylinder") },
+            Type("entity") : { Type("object"), Type("animal") },
+        }
 
-    assert domain.type_to_parent_types == {
-        Type("entity") : { Type("entity") },
-        Type("object") : { Type("object"), Type("entity") },
-        Type("animal") : { Type("animal"), Type("entity") },
-        Type("dog") : { Type("dog"), Type("animal"), Type("entity") },
-        Type("cat") : { Type("cat"), Type("animal"), Type("entity") },
-        Type("corgi") : { Type("corgi"), Type("dog"), Type("animal"), Type("entity") },
-        Type("jindo") : { Type("jindo"), Type("dog"), Type("animal"), Type("entity") },
-        Type("block") : { Type("block"), Type("object"), Type("entity") },
-        Type("cylinder") : { Type("cylinder"), Type("object"), Type("entity") },
-    }
+        assert domain.type_to_parent_types == {
+            Type("entity") : { Type("entity") },
+            Type("object") : { Type("object"), Type("entity") },
+            Type("animal") : { Type("animal"), Type("entity") },
+            Type("dog") : { Type("dog"), Type("animal"), Type("entity") },
+            Type("cat") : { Type("cat"), Type("animal"), Type("entity") },
+            Type("corgi") : { Type("corgi"), Type("dog"), Type("animal"), Type("entity") },
+            Type("jindo") : { Type("jindo"), Type("dog"), Type("animal"), Type("entity") },
+            Type("block") : { Type("block"), Type("object"), Type("entity") },
+            Type("cylinder") : { Type("cylinder"), Type("object"), Type("entity") },
+        }
 
-    print("Test passed.")
+        print("Test passed.")
 
 if __name__ == "__main__":
-    test_parser()
-    test_hierarchical_types()
+    unittest.main()

--- a/pddlgym/tests/test_pddlenv.py
+++ b/pddlgym/tests/test_pddlenv.py
@@ -2,360 +2,350 @@ from pddlgym.core import PDDLEnv, InvalidAction
 from pddlgym.structs import Predicate, Type, LiteralConjunction
 
 import os
+import unittest
+
+class TestPDDLEnv(unittest.TestCase):
+    def test_pddlenv(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        domain_file = os.path.join(dir_path, 'pddl', 'test_domain.pddl')
+        problem_dir = os.path.join(dir_path, 'pddl', 'test_domain')
+
+        env = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
+                    dynamic_action_space=True)
+        env2 = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
+                    dynamic_action_space=False)
+
+        type1 = Type('type1')
+        type2 = Type('type2')
+        pred1 = Predicate('pred1', 1, [type1])
+        pred2 = Predicate('pred2', 1, [type2])
+        pred3 = Predicate('pred3', 3, [type1, type2, type2])
+        action_pred = Predicate('actionpred', 1, [type1])
+
+        obs, _ = env.reset()
+
+        assert obs.literals == frozenset({ pred1('b2'), pred2('c1'), pred3('a1', 'c1', 'd1'), 
+            pred3('a2', 'c2', 'd2') })
+
+        # Invalid action
+        action = action_pred('b1')
+
+        try:
+            env.step(action)
+            assert False, "Action was supposed to be invalid"
+        except InvalidAction:
+            pass
+
+        assert action not in env.action_space.all_ground_literals(obs), "Dynamic action space not working"
+        env2.reset()
+        assert action in env2.action_space.all_ground_literals(obs), "Dynamic action space not working"
+
+        # Valid args
+        action = action_pred('b2')
+
+        obs, _, _, _ = env.step(action)
+
+        assert obs.literals == frozenset({ pred1('b2'), pred3('b2', 'd1', 'c1'), 
+            pred3('a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2') })
+
+        assert isinstance(obs.goal, LiteralConjunction)
+        assert set(obs.goal.literals) == {pred2('c2'), pred3('b1', 'c1', 'd1')}
 
 
-def test_pddlenv():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    domain_file = os.path.join(dir_path, 'pddl', 'test_domain.pddl')
-    problem_dir = os.path.join(dir_path, 'pddl', 'test_domain')
+    def test_pddlenv_hierarchical_types(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        domain_file = os.path.join(dir_path, 'pddl', 'hierarchical_type_test_domain.pddl')
+        problem_dir = os.path.join(dir_path, 'pddl', 'hierarchical_type_test_domain')
 
-    env = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
-                  dynamic_action_space=True)
-    env2 = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
-                   dynamic_action_space=False)
+        env = PDDLEnv(domain_file, problem_dir)
+        obs, _ = env.reset()
 
-    type1 = Type('type1')
-    type2 = Type('type2')
-    pred1 = Predicate('pred1', 1, [type1])
-    pred2 = Predicate('pred2', 1, [type2])
-    pred3 = Predicate('pred3', 3, [type1, type2, type2])
-    action_pred = Predicate('actionpred', 1, [type1])
+        ispresent = Predicate("ispresent", 1, [Type("entity")])
+        islight = Predicate("islight", 1, [Type("object")])
+        isfurry = Predicate("isfurry", 1, [Type("animal")])
+        ishappy = Predicate("ishappy", 1, [Type("animal")])
+        pet = Predicate("pet", 1, [Type("animal")])
 
-    obs, _ = env.reset()
+        nomsy = Type("jindo")("nomsy")
+        rover = Type("corgi")("rover")
+        rene = Type("cat")("rene")
+        block1 = Type("block")("block1")
+        block2 = Type("block")("block2")
+        cylinder1 = Type("cylinder")("cylinder1")
 
-    assert obs.literals == frozenset({ pred1('b2'), pred2('c1'), pred3('a1', 'c1', 'd1'), 
-        pred3('a2', 'c2', 'd2') })
+        assert obs.literals == frozenset({
+            ispresent(nomsy),
+            ispresent(rover),
+            ispresent(rene),
+            ispresent(block1),
+            ispresent(block2),
+            ispresent(cylinder1),
+            islight(block1),
+            islight(cylinder1),
+            isfurry(nomsy),
+        })
 
-    # Invalid action
-    action = action_pred('b1')
+        obs, _, _, _ = env.step(pet('block1'))
 
-    try:
-        env.step(action)
-        assert False, "Action was supposed to be invalid"
-    except InvalidAction:
-        pass
+        assert obs.literals == frozenset({
+            ispresent(nomsy),
+            ispresent(rover),
+            ispresent(rene),
+            ispresent(block1),
+            ispresent(block2),
+            ispresent(cylinder1),
+            islight(block1),
+            islight(cylinder1),
+            isfurry(nomsy),
+        })
 
-    assert action not in env.action_space.all_ground_literals(obs), "Dynamic action space not working"
-    env2.reset()
-    assert action in env2.action_space.all_ground_literals(obs), "Dynamic action space not working"
+        obs, _, _, _ = env.step(pet(nomsy))
 
-    # Valid args
-    action = action_pred('b2')
-
-    obs, _, _, _ = env.step(action)
-
-    assert obs.literals == frozenset({ pred1('b2'), pred3('b2', 'd1', 'c1'), 
-        pred3('a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2') })
-
-    assert isinstance(obs.goal, LiteralConjunction)
-    assert set(obs.goal.literals) == {pred2('c2'), pred3('b1', 'c1', 'd1')}
-
-    print("Test passed.")
-
-
-def test_pddlenv_hierarchical_types():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    domain_file = os.path.join(dir_path, 'pddl', 'hierarchical_type_test_domain.pddl')
-    problem_dir = os.path.join(dir_path, 'pddl', 'hierarchical_type_test_domain')
-
-    env = PDDLEnv(domain_file, problem_dir)
-    obs, _ = env.reset()
-
-    ispresent = Predicate("ispresent", 1, [Type("entity")])
-    islight = Predicate("islight", 1, [Type("object")])
-    isfurry = Predicate("isfurry", 1, [Type("animal")])
-    ishappy = Predicate("ishappy", 1, [Type("animal")])
-    pet = Predicate("pet", 1, [Type("animal")])
-
-    nomsy = Type("jindo")("nomsy")
-    rover = Type("corgi")("rover")
-    rene = Type("cat")("rene")
-    block1 = Type("block")("block1")
-    block2 = Type("block")("block2")
-    cylinder1 = Type("cylinder")("cylinder1")
-
-    assert obs.literals == frozenset({
-        ispresent(nomsy),
-        ispresent(rover),
-        ispresent(rene),
-        ispresent(block1),
-        ispresent(block2),
-        ispresent(cylinder1),
-        islight(block1),
-        islight(cylinder1),
-        isfurry(nomsy),
-    })
-
-    obs, _, _, _ = env.step(pet('block1'))
-
-    assert obs.literals == frozenset({
-        ispresent(nomsy),
-        ispresent(rover),
-        ispresent(rene),
-        ispresent(block1),
-        ispresent(block2),
-        ispresent(cylinder1),
-        islight(block1),
-        islight(cylinder1),
-        isfurry(nomsy),
-    })
-
-    obs, _, _, _ = env.step(pet(nomsy))
-
-    assert obs.literals == frozenset({
-        ispresent(nomsy),
-        ispresent(rover),
-        ispresent(rene),
-        ispresent(block1),
-        ispresent(block2),
-        ispresent(cylinder1),
-        islight(block1),
-        islight(cylinder1),
-        isfurry(nomsy),
-        ishappy(nomsy)
-    })
-
-    print("Test passed.")
+        assert obs.literals == frozenset({
+            ispresent(nomsy),
+            ispresent(rover),
+            ispresent(rene),
+            ispresent(block1),
+            ispresent(block2),
+            ispresent(cylinder1),
+            islight(block1),
+            islight(cylinder1),
+            isfurry(nomsy),
+            ishappy(nomsy)
+        })
 
 
-def test_get_all_possible_transitions():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    domain_file = os.path.join(
-        dir_path, 'pddl', 'test_probabilistic_domain.pddl')
-    problem_dir = os.path.join(dir_path, 'pddl', 'test_probabilistic_domain')
 
-    env = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
-                  dynamic_action_space=True)
 
-    obs, _ = env.reset()
-    action = env.action_space.all_ground_literals(obs).pop()
-    transitions = env.get_all_possible_transitions(action)
+    def test_get_all_possible_transitions(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        domain_file = os.path.join(
+            dir_path, 'pddl', 'test_probabilistic_domain.pddl')
+        problem_dir = os.path.join(dir_path, 'pddl', 'test_probabilistic_domain')
 
-    transition_list = list(transitions)
-    assert len(transition_list) == 2
-    state1, state2 = transition_list[0][0], transition_list[1][0]
+        env = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
+                    dynamic_action_space=True)
 
-    type1 = Type('type1')
-    type2 = Type('type2')
-    pred1 = Predicate('pred1', 1, [type1])
-    pred2 = Predicate('pred2', 1, [type2])
-    pred3 = Predicate('pred3', 3, [type1, type2, type2])
+        obs, _ = env.reset()
+        action = env.action_space.all_ground_literals(obs).pop()
+        transitions = env.get_all_possible_transitions(action)
 
-    state1, state2 = (state1, state2) if pred2(
-        'c1') in state2.literals else (state2, state1)
+        transition_list = list(transitions)
+        assert len(transition_list) == 2
+        state1, state2 = transition_list[0][0], transition_list[1][0]
 
-    assert state1.literals == frozenset({pred1('b2'), pred3(
-        'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
-    assert state2.literals == frozenset({pred1('b2'), pred2('c1'), pred3(
-        'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
+        type1 = Type('type1')
+        type2 = Type('type2')
+        pred1 = Predicate('pred1', 1, [type1])
+        pred2 = Predicate('pred2', 1, [type2])
+        pred3 = Predicate('pred3', 3, [type1, type2, type2])
 
-    # Now test again with return_probs=True.
-    transitions = env.get_all_possible_transitions(action, return_probs=True)
+        state1, state2 = (state1, state2) if pred2(
+            'c1') in state2.literals else (state2, state1)
 
-    transition_list = list(transitions)
-    assert len(transition_list) == 2
-    assert abs(transition_list[0][1]-0.3) < 1e-5 or abs(transition_list[0][1]-0.7) < 1e-5
-    assert abs(transition_list[1][1]-0.3) < 1e-5 or abs(transition_list[1][1]-0.7) < 1e-5
-    assert abs(transition_list[0][1]-transition_list[1][1]) > 0.3
-    state1, state2 = transition_list[0][0][0], transition_list[1][0][0]
-
-    type1 = Type('type1')
-    type2 = Type('type2')
-    pred1 = Predicate('pred1', 1, [type1])
-    pred2 = Predicate('pred2', 1, [type2])
-    pred3 = Predicate('pred3', 3, [type1, type2, type2])
-
-    state1, state2 = (state1, state2) if pred2(
-        'c1') in state2.literals else (state2, state1)
-
-    assert state1.literals == frozenset({pred1('b2'), pred3(
-        'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
-    assert state2.literals == frozenset({pred1('b2'), pred2('c1'), pred3(
-        'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
-
-    print("Test passed.")
-
-def test_get_all_possible_transitions_multiple_independent_effects():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    domain_file = os.path.join(
-        dir_path, 'pddl', 'test_probabilistic_domain_alt.pddl')
-    problem_dir = os.path.join(dir_path, 'pddl', 'test_probabilistic_domain_alt')
-
-    env = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
-                  dynamic_action_space=True)
-
-    obs, _ = env.reset()
-    action = env.action_space.all_ground_literals(obs).pop()
-    transitions = env.get_all_possible_transitions(action)
-
-    transition_list = list(transitions)
-    assert len(transition_list) == 4
-
-    states = set({
-        transition_list[0][0].literals, transition_list[1][0].literals,
-        transition_list[2][0].literals, transition_list[3][0].literals
-    })
-
-    type1 = Type('type1')
-    type2 = Type('type2')
-    pred1 = Predicate('pred1', 1, [type1])
-    pred2 = Predicate('pred2', 1, [type2])
-    pred3 = Predicate('pred3', 3, [type1, type2, type2])
-
-    expected_states = set({
-        frozenset({pred1('b2'), pred3(
-            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}),
-        frozenset({pred1('b2'), pred3(
-            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')}),
-        frozenset({pred1('b2'), pred2('c1'), pred3(
-            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}),
-        frozenset({pred1('b2'), pred2('c1'), pred3(
+        assert state1.literals == frozenset({pred1('b2'), pred3(
             'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
-    })
-
-    assert states == expected_states
-
-    # Now test again with return_probs=True.
-    transitions = env.get_all_possible_transitions(action, return_probs=True)
-
-    transition_list = list(transitions)
-    assert len(transition_list) == 4
-    states_and_probs = {
-        transition_list[0][0][0].literals: transition_list[0][1],
-        transition_list[1][0][0].literals: transition_list[1][1],
-        transition_list[2][0][0].literals: transition_list[2][1],
-        transition_list[3][0][0].literals: transition_list[3][1]
-    }
-
-    type1 = Type('type1')
-    type2 = Type('type2')
-    pred1 = Predicate('pred1', 1, [type1])
-    pred2 = Predicate('pred2', 1, [type2])
-    pred3 = Predicate('pred3', 3, [type1, type2, type2])
-
-    expected_states = {
-        frozenset({pred1('b2'), pred3(
-            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}): 0.225,
-        frozenset({pred1('b2'), pred3(
-            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')}): 0.075,
-        frozenset({pred1('b2'), pred2('c1'), pred3(
-            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}): 0.525,
-        frozenset({pred1('b2'), pred2('c1'), pred3(
-            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')}): 0.175
-    }
-
-    for s, prob in states_and_probs.items():
-        assert s in expected_states
-        assert prob - expected_states[s] < 1e-5
-
-    print("Test passed.")
-
-def test_get_all_possible_transitions_multiple_effects():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    domain_file = os.path.join(
-        dir_path, 'pddl', 'test_probabilistic_domain_alt_2.pddl')
-    problem_dir = os.path.join(dir_path, 'pddl', 'test_probabilistic_domain_alt_2')
-
-    env = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
-                  dynamic_action_space=True)
-
-    obs, _ = env.reset()
-    action = env.action_space.all_ground_literals(obs).pop()
-    transitions = env.get_all_possible_transitions(action)
-
-    transition_list = list(transitions)
-    assert len(transition_list) == 3
-
-    states = set({
-        transition_list[0][0].literals,
-        transition_list[1][0].literals,
-        transition_list[2][0].literals
-    })
-
-    type1 = Type('type1')
-    type2 = Type('type2')
-    pred1 = Predicate('pred1', 1, [type1])
-    pred2 = Predicate('pred2', 1, [type2])
-    pred3 = Predicate('pred3', 3, [type1, type2, type2])
-
-    expected_states = set({
-        frozenset({pred1('b2'), pred3(
-            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}),
-        frozenset({pred2('c1'), pred3(
-            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}),
-        frozenset({pred1('b2'), pred2('c1'), pred3(
+        assert state2.literals == frozenset({pred1('b2'), pred2('c1'), pred3(
             'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
-    })
 
-    assert states == expected_states
+        # Now test again with return_probs=True.
+        transitions = env.get_all_possible_transitions(action, return_probs=True)
 
-    # Now test again with return_probs=True.
-    transitions = env.get_all_possible_transitions(action, return_probs=True)
+        transition_list = list(transitions)
+        assert len(transition_list) == 2
+        assert abs(transition_list[0][1]-0.3) < 1e-5 or abs(transition_list[0][1]-0.7) < 1e-5
+        assert abs(transition_list[1][1]-0.3) < 1e-5 or abs(transition_list[1][1]-0.7) < 1e-5
+        assert abs(transition_list[0][1]-transition_list[1][1]) > 0.3
+        state1, state2 = transition_list[0][0][0], transition_list[1][0][0]
 
-    transition_list = list(transitions)
-    assert len(transition_list) == 3
-    states_and_probs = {
-        transition_list[0][0][0].literals: transition_list[0][1],
-        transition_list[1][0][0].literals: transition_list[1][1],
-        transition_list[2][0][0].literals: transition_list[2][1]
-    }
+        type1 = Type('type1')
+        type2 = Type('type2')
+        pred1 = Predicate('pred1', 1, [type1])
+        pred2 = Predicate('pred2', 1, [type2])
+        pred3 = Predicate('pred3', 3, [type1, type2, type2])
 
-    type1 = Type('type1')
-    type2 = Type('type2')
-    pred1 = Predicate('pred1', 1, [type1])
-    pred2 = Predicate('pred2', 1, [type2])
-    pred3 = Predicate('pred3', 3, [type1, type2, type2])
+        state1, state2 = (state1, state2) if pred2(
+            'c1') in state2.literals else (state2, state1)
 
-    expected_states = {
-        frozenset({pred1('b2'), pred3(
-            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}): 0.5,
-        frozenset({pred2('c1'), pred3(
-            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}): 0.4,
-        frozenset({pred1('b2'), pred2('c1'), pred3(
-            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')}): 0.1
-    }
+        assert state1.literals == frozenset({pred1('b2'), pred3(
+            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
+        assert state2.literals == frozenset({pred1('b2'), pred2('c1'), pred3(
+            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
 
-    for s, prob in states_and_probs.items():
-        assert s in expected_states
-        assert prob - expected_states[s] < 1e-5
 
-    print("Test passed.")
+    def test_get_all_possible_transitions_multiple_independent_effects(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        domain_file = os.path.join(
+            dir_path, 'pddl', 'test_probabilistic_domain_alt.pddl')
+        problem_dir = os.path.join(dir_path, 'pddl', 'test_probabilistic_domain_alt')
 
-def test_determinize():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    domain_file = os.path.join(
-        dir_path, 'pddl', 'test_probabilistic_domain.pddl')
-    problem_dir = os.path.join(dir_path, 'pddl', 'test_probabilistic_domain')
+        env = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
+                    dynamic_action_space=True)
 
-    env = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
-                  dynamic_action_space=True)
-    env.domain.determinize()
+        obs, _ = env.reset()
+        action = env.action_space.all_ground_literals(obs).pop()
+        transitions = env.get_all_possible_transitions(action)
 
-    obs, _ = env.reset()
-    action = env.action_space.all_ground_literals(obs).pop()
-    transitions = env.get_all_possible_transitions(action, return_probs=True)
+        transition_list = list(transitions)
+        assert len(transition_list) == 4
 
-    transition_list = list(transitions)
-    assert len(transition_list) == 1
-    assert transition_list[0][1] == 1.0
-    newstate = transition_list[0][0][0]
+        states = set({
+            transition_list[0][0].literals, transition_list[1][0].literals,
+            transition_list[2][0].literals, transition_list[3][0].literals
+        })
 
-    type1 = Type('type1')
-    type2 = Type('type2')
-    pred1 = Predicate('pred1', 1, [type1])
-    pred2 = Predicate('pred2', 1, [type2])
-    pred3 = Predicate('pred3', 3, [type1, type2, type2])
+        type1 = Type('type1')
+        type2 = Type('type2')
+        pred1 = Predicate('pred1', 1, [type1])
+        pred2 = Predicate('pred2', 1, [type2])
+        pred3 = Predicate('pred3', 3, [type1, type2, type2])
 
-    assert newstate.literals == frozenset({pred1('b2'), pred2('c1'), pred3(
-        'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
+        expected_states = set({
+            frozenset({pred1('b2'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}),
+            frozenset({pred1('b2'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')}),
+            frozenset({pred1('b2'), pred2('c1'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}),
+            frozenset({pred1('b2'), pred2('c1'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
+        })
 
-    print("Test passed.")
+        assert states == expected_states
+
+        # Now test again with return_probs=True.
+        transitions = env.get_all_possible_transitions(action, return_probs=True)
+
+        transition_list = list(transitions)
+        assert len(transition_list) == 4
+        states_and_probs = {
+            transition_list[0][0][0].literals: transition_list[0][1],
+            transition_list[1][0][0].literals: transition_list[1][1],
+            transition_list[2][0][0].literals: transition_list[2][1],
+            transition_list[3][0][0].literals: transition_list[3][1]
+        }
+
+        type1 = Type('type1')
+        type2 = Type('type2')
+        pred1 = Predicate('pred1', 1, [type1])
+        pred2 = Predicate('pred2', 1, [type2])
+        pred3 = Predicate('pred3', 3, [type1, type2, type2])
+
+        expected_states = {
+            frozenset({pred1('b2'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}): 0.225,
+            frozenset({pred1('b2'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')}): 0.075,
+            frozenset({pred1('b2'), pred2('c1'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}): 0.525,
+            frozenset({pred1('b2'), pred2('c1'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')}): 0.175
+        }
+
+        for s, prob in states_and_probs.items():
+            assert s in expected_states
+            assert prob - expected_states[s] < 1e-5
+
+
+    def test_get_all_possible_transitions_multiple_effects(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        domain_file = os.path.join(
+            dir_path, 'pddl', 'test_probabilistic_domain_alt_2.pddl')
+        problem_dir = os.path.join(dir_path, 'pddl', 'test_probabilistic_domain_alt_2')
+
+        env = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
+                    dynamic_action_space=True)
+
+        obs, _ = env.reset()
+        action = env.action_space.all_ground_literals(obs).pop()
+        transitions = env.get_all_possible_transitions(action)
+
+        transition_list = list(transitions)
+        assert len(transition_list) == 3
+
+        states = set({
+            transition_list[0][0].literals,
+            transition_list[1][0].literals,
+            transition_list[2][0].literals
+        })
+
+        type1 = Type('type1')
+        type2 = Type('type2')
+        pred1 = Predicate('pred1', 1, [type1])
+        pred2 = Predicate('pred2', 1, [type2])
+        pred3 = Predicate('pred3', 3, [type1, type2, type2])
+
+        expected_states = set({
+            frozenset({pred1('b2'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}),
+            frozenset({pred2('c1'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}),
+            frozenset({pred1('b2'), pred2('c1'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
+        })
+
+        assert states == expected_states
+
+        # Now test again with return_probs=True.
+        transitions = env.get_all_possible_transitions(action, return_probs=True)
+
+        transition_list = list(transitions)
+        assert len(transition_list) == 3
+        states_and_probs = {
+            transition_list[0][0][0].literals: transition_list[0][1],
+            transition_list[1][0][0].literals: transition_list[1][1],
+            transition_list[2][0][0].literals: transition_list[2][1]
+        }
+
+        type1 = Type('type1')
+        type2 = Type('type2')
+        pred1 = Predicate('pred1', 1, [type1])
+        pred2 = Predicate('pred2', 1, [type2])
+        pred3 = Predicate('pred3', 3, [type1, type2, type2])
+
+        expected_states = {
+            frozenset({pred1('b2'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}): 0.5,
+            frozenset({pred2('c1'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2')}): 0.4,
+            frozenset({pred1('b2'), pred2('c1'), pred3(
+                'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')}): 0.1
+        }
+
+        for s, prob in states_and_probs.items():
+            assert s in expected_states
+            assert prob - expected_states[s] < 1e-5
+
+
+    def test_determinize(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        domain_file = os.path.join(
+            dir_path, 'pddl', 'test_probabilistic_domain.pddl')
+        problem_dir = os.path.join(dir_path, 'pddl', 'test_probabilistic_domain')
+
+        env = PDDLEnv(domain_file, problem_dir, raise_error_on_invalid_action=True,
+                    dynamic_action_space=True)
+        env.domain.determinize()
+
+        obs, _ = env.reset()
+        action = env.action_space.all_ground_literals(obs).pop()
+        transitions = env.get_all_possible_transitions(action, return_probs=True)
+
+        transition_list = list(transitions)
+        assert len(transition_list) == 1
+        assert transition_list[0][1] == 1.0
+        newstate = transition_list[0][0][0]
+
+        type1 = Type('type1')
+        type2 = Type('type2')
+        pred1 = Predicate('pred1', 1, [type1])
+        pred2 = Predicate('pred2', 1, [type2])
+        pred3 = Predicate('pred3', 3, [type1, type2, type2])
+
+        assert newstate.literals == frozenset({pred1('b2'), pred2('c1'), pred3(
+            'a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2'), pred3('b2', 'd1', 'c1')})
+
 
 
 if __name__ == "__main__":
-    test_pddlenv()
-    test_pddlenv_hierarchical_types()
-    test_get_all_possible_transitions()
-    test_get_all_possible_transitions_multiple_effects()
-    test_get_all_possible_transitions_multiple_independent_effects()
-    test_determinize()
+    unittest.main()

--- a/pddlgym/tests/test_searchandrescue.py
+++ b/pddlgym/tests/test_searchandrescue.py
@@ -1,91 +1,93 @@
 import pddlgym
 import numpy as np
 
-def test_searchandrescue(num_actions_to_test=10, verbose=False):
-    """Test state encoding and decoding
-    """
-    for level in range(1, 7):
-        env = pddlgym.make(f"SearchAndRescueLevel{level}-v0")
-        if level == 1:
-            assert len(env.problems) == 20
-        else:
-            assert len(env.problems) == 50
-        env.fix_problem_index(0)
-        state, debug_info = env.reset()
-        rng = np.random.RandomState(0)
+import unittest
 
-        all_actions = env.get_possible_actions()
-        actions = rng.choice(all_actions, size=num_actions_to_test)
-        done = False
-        for t, act in enumerate(actions):
-            if verbose:
-                print(f"Taking action {t}/{num_actions_to_test}", end='\r', flush=True)
 
-            assert state == env._internal_to_state(env._state)
-            assert env._state.literals == env._state_to_internal(state).literals
-            assert env._state.objects == env._state_to_internal(state).objects
-            assert set(env._state.goal.literals) == set(env._state_to_internal(state).goal.literals)
-            assert env.check_goal(state) == done
-            for a in all_actions:
-                ns = env.get_successor_state(state, a)
-                assert ns == env._internal_to_state(env._state_to_internal(ns))
-
-            if done:
-                break
-            state, _, done, _ = env.step(act)
-        if verbose:
-            print()
-
-    print("Test passed.")
-
-def test_searchandrescue_walls(num_actions_to_test=10):
-    """Test that when we try to move into walls, we stay put.
-    """
-    rng = np.random.RandomState(0)
-    for level in [1, 2]:
-        env = pddlgym.make(f"SearchAndRescueLevel{level}-v0")
-        for idx in range(len(env.problems)):
-            env.fix_problem_index(idx)
+class TestSearchAndRescue(unittest.TestCase):
+    def skip_test_searchandrescue(self, num_actions_to_test=10, verbose=False):
+        """Test state encoding and decoding
+        """
+        for level in range(1, 7):
+            env = pddlgym.make(f"SearchAndRescueLevel{level}-v0")
+            if level == 1:
+                assert len(env.problems) == 20
+            else:
+                assert len(env.problems) == 50
+            env.fix_problem_index(0)
             state, debug_info = env.reset()
+            rng = np.random.RandomState(0)
 
-            all_actions = dropoff, down, left, right, up, pickup = env.get_possible_actions()
-
-            act_to_delta = {
-                dropoff : (0, 0),
-                down : (1, 0),
-                left : (0, -1),
-                right : (0, 1),
-                up : (-1, 0),
-                pickup : (0, 0),
-            }
-
+            all_actions = env.get_possible_actions()
             actions = rng.choice(all_actions, size=num_actions_to_test)
             done = False
-            robot_r, robot_c = dict(state)["robot0"]
-            walls = { dict(state)[k] for k in dict(state) if k.startswith("wall") } 
             for t, act in enumerate(actions):
+                if verbose:
+                    print(f"Taking action {t}/{num_actions_to_test}", end='\r', flush=True)
 
-                dr, dc = act_to_delta[act]
-                can_r, can_c = robot_r + dr, robot_c + dc
+                assert state == env._internal_to_state(env._state)
+                assert env._state.literals == env._state_to_internal(state).literals
+                assert env._state.objects == env._state_to_internal(state).objects
+                assert set(env._state.goal.literals) == set(env._state_to_internal(state).goal.literals)
+                assert env.check_goal(state) == done
+                for a in all_actions:
+                    ns = env.get_successor_state(state, a)
+                    assert ns == env._internal_to_state(env._state_to_internal(ns))
 
                 if done:
                     break
-                state1, _, done, _ = env.step(act)
-                state2 = env.get_successor_state(state, act)
-                assert state2 == state1
-                state = state1
+                state, _, done, _ = env.step(act)
+            if verbose:
+                print()
 
-                new_r, new_c = dict(state)["robot0"]
 
-                if (can_r, can_c) in walls:
-                    # Can't move into walls!
-                    assert (new_r, new_c) == (robot_r, robot_c)
+    def test_searchandrescue_walls(self, num_actions_to_test=10):
+        """Test that when we try to move into walls, we stay put.
+        """
+        rng = np.random.RandomState(0)
+        for level in [1, 2]:
+            env = pddlgym.make(f"SearchAndRescueLevel{level}-v0")
+            for idx in range(len(env.problems)):
+                env.fix_problem_index(idx)
+                state, debug_info = env.reset()
 
-                robot_r, robot_c = new_r, new_c
+                all_actions = dropoff, down, left, right, up, pickup = env.get_possible_actions()
 
-    print("Test passed.")
+                act_to_delta = {
+                    dropoff : (0, 0),
+                    down : (1, 0),
+                    left : (0, -1),
+                    right : (0, 1),
+                    up : (-1, 0),
+                    pickup : (0, 0),
+                }
+
+                actions = rng.choice(all_actions, size=num_actions_to_test)
+                done = False
+                robot_r, robot_c = dict(state)["robot0"]
+                walls = { dict(state)[k] for k in dict(state) if k.startswith("wall") } 
+                for t, act in enumerate(actions):
+
+                    dr, dc = act_to_delta[act]
+                    can_r, can_c = robot_r + dr, robot_c + dc
+
+                    if done:
+                        break
+                    state1, _, done, _ = env.step(act)
+                    state2 = env.get_successor_state(state, act)
+                    assert state2 == state1
+                    state = state1
+
+                    new_r, new_c = dict(state)["robot0"]
+
+                    if (can_r, can_c) in walls:
+                        # Can't move into walls!
+                        assert (new_r, new_c) == (robot_r, robot_c)
+
+                    robot_r, robot_c = new_r, new_c
 
 
 if __name__ == "__main__":
     # test_searchandrescue(verbose=True)
-    test_searchandrescue_walls()
+    # test_searchandrescue_walls()
+    unittest.main()

--- a/pddlgym/tests/test_spaces.py
+++ b/pddlgym/tests/test_spaces.py
@@ -5,161 +5,157 @@ from pddlgym.core import PDDLEnv
 
 import os
 import time
+import unittest
 
 
-def test_hierarchical_spaces():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    domain_file = os.path.join(dir_path, 'pddl', 'hierarchical_type_test_domain.pddl')
-    problem_file = os.path.join(dir_path, 'pddl', 'hierarchical_type_test_domain', 
-        'hierarchical_type_test_problem.pddl')
-    domain = PDDLDomainParser(domain_file)
-    problem = PDDLProblemParser(problem_file, domain.domain_name, domain.types,
-        domain.predicates, domain.actions)
-    actions = list(domain.actions)
-    action_predicates = [domain.predicates[a] for a in actions]
+class TestSpaces(unittest.TestCase):
+    def test_hierarchical_spaces(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        domain_file = os.path.join(dir_path, 'pddl', 'hierarchical_type_test_domain.pddl')
+        problem_file = os.path.join(dir_path, 'pddl', 'hierarchical_type_test_domain', 
+            'hierarchical_type_test_problem.pddl')
+        domain = PDDLDomainParser(domain_file)
+        problem = PDDLProblemParser(problem_file, domain.domain_name, domain.types,
+            domain.predicates, domain.actions)
+        actions = list(domain.actions)
+        action_predicates = [domain.predicates[a] for a in actions]
 
-    space = LiteralSpace(set(domain.predicates.values()) - set(action_predicates),
-        type_to_parent_types=domain.type_to_parent_types)
-    all_ground_literals = space.all_ground_literals(State(problem.initial_state, 
-        problem.objects, problem.goal))
+        space = LiteralSpace(set(domain.predicates.values()) - set(action_predicates),
+            type_to_parent_types=domain.type_to_parent_types)
+        all_ground_literals = space.all_ground_literals(State(problem.initial_state, 
+            problem.objects, problem.goal))
 
-    ispresent = Predicate("ispresent", 1, [Type("entity")])
-    islight = Predicate("islight", 1, [Type("object")])
-    isfurry = Predicate("isfurry", 1, [Type("animal")])
-    ishappy = Predicate("ishappy", 1, [Type("animal")])
-    attending = Predicate("attending", 2, [Type("animal"), Type("object")])
+        ispresent = Predicate("ispresent", 1, [Type("entity")])
+        islight = Predicate("islight", 1, [Type("object")])
+        isfurry = Predicate("isfurry", 1, [Type("animal")])
+        ishappy = Predicate("ishappy", 1, [Type("animal")])
+        attending = Predicate("attending", 2, [Type("animal"), Type("object")])
 
-    nomsy = Type("jindo")("nomsy")
-    rover = Type("corgi")("rover")
-    rene = Type("cat")("rene")
-    block1 = Type("block")("block1")
-    block2 = Type("block")("block2")
-    cylinder1 = Type("cylinder")("cylinder1")
+        nomsy = Type("jindo")("nomsy")
+        rover = Type("corgi")("rover")
+        rene = Type("cat")("rene")
+        block1 = Type("block")("block1")
+        block2 = Type("block")("block2")
+        cylinder1 = Type("cylinder")("cylinder1")
 
-    assert all_ground_literals == {
-        ispresent(nomsy),
-        ispresent(rover),
-        ispresent(rene),
-        ispresent(block1),
-        ispresent(block2),
-        ispresent(cylinder1),
-        islight(block1),
-        islight(block2),
-        islight(cylinder1),
-        isfurry(nomsy),
-        isfurry(rover),
-        isfurry(rene),
-        ishappy(nomsy),
-        ishappy(rover),
-        ishappy(rene),
-        attending(nomsy, block1),
-        attending(nomsy, block2),
-        attending(nomsy, cylinder1),
-        attending(rover, block1),
-        attending(rover, block2),
-        attending(rover, cylinder1),
-        attending(rene, block1),
-        attending(rene, block2),
-        attending(rene, cylinder1),
-    }
-
-    print("Test passed.")
+        assert all_ground_literals == {
+            ispresent(nomsy),
+            ispresent(rover),
+            ispresent(rene),
+            ispresent(block1),
+            ispresent(block2),
+            ispresent(cylinder1),
+            islight(block1),
+            islight(block2),
+            islight(cylinder1),
+            isfurry(nomsy),
+            isfurry(rover),
+            isfurry(rene),
+            ishappy(nomsy),
+            ishappy(rover),
+            ishappy(rene),
+            attending(nomsy, block1),
+            attending(nomsy, block2),
+            attending(nomsy, cylinder1),
+            attending(rover, block1),
+            attending(rover, block2),
+            attending(rover, cylinder1),
+            attending(rene, block1),
+            attending(rene, block2),
+            attending(rene, cylinder1),
+        }
 
 
-def test_dynamic_action_space(verbose=False):
-    """
-    """
-    dir_path = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "pddl")
 
-    for name in [
-            # "Manymiconic",
-            # "Manygripper",
-            "Blocks_operator_actions",
-            "Hanoi_operator_actions",
-        ]:
+    def test_dynamic_action_space(self, verbose=False):
+        """
+        """
+        dir_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "pddl")
+
+        for name in [
+                # "Manymiconic",
+                # "Manygripper",
+                "Blocks_operator_actions",
+                "Hanoi_operator_actions",
+            ]:
+            domain_file = os.path.join(dir_path, "{}.pddl".format(name.lower()))
+            problem_dir = os.path.join(dir_path, name.lower())
+            # problem_dir = os.path.join(dir_path, name.lower()+"_test")
+
+            env1 = PDDLEnv(domain_file, problem_dir,
+                operators_as_actions=True,
+                dynamic_action_space=False,
+            )
+
+            env2 = PDDLEnv(domain_file, problem_dir,
+                operators_as_actions=True,
+                dynamic_action_space=True,
+            )
+
+            env1.action_space.seed(0)
+            env2.action_space.seed(0)
+            state1, _ = env1.reset()
+            state2, _ = env2.reset()
+            assert state1 == state2
+
+            for _ in range(25):
+                start_time = time.time()
+                valid_actions1 = env1.action_space.all_ground_literals(state1)
+                if verbose:
+                    print("Computing valid action spaces without instantiator took {} seconds".format(
+                        time.time() - start_time))
+                start_time = time.time()
+                valid_actions2 = env2.action_space.all_ground_literals(state2)
+                if verbose:
+                    print("Computing valid action spaces *with* instantiator took {} seconds".format(
+                        time.time() - start_time))
+                assert valid_actions2.issubset(valid_actions1)
+                action = env2.action_space.sample(state2)
+                state1, _, _, _ = env1.step(action)
+                state2, _, _, _ = env2.step(action)
+
+            if verbose:
+                print("Test passed for environment {}.".format(name))
+
+
+
+    def test_dynamic_action_space_same_obj(self):
+        """
+        """
+        dir_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "pddl")
+
+        name = "dynamic_action_space_same_obj"
         domain_file = os.path.join(dir_path, "{}.pddl".format(name.lower()))
         problem_dir = os.path.join(dir_path, name.lower())
-        # problem_dir = os.path.join(dir_path, name.lower()+"_test")
 
-        env1 = PDDLEnv(domain_file, problem_dir,
-            operators_as_actions=True,
-            dynamic_action_space=False,
-        )
-
-        env2 = PDDLEnv(domain_file, problem_dir,
+        env = PDDLEnv(domain_file, problem_dir,
             operators_as_actions=True,
             dynamic_action_space=True,
         )
+        assert len(env.problems) == 2  # both problems have the same object set
 
-        env1.action_space.seed(0)
-        env2.action_space.seed(0)
-        state1, _ = env1.reset()
-        state2, _ = env2.reset()
-        assert state1 == state2
-
+        env.fix_problem_index(0)
+        state1, _ = env.reset()
+        # Only one action is possible: unstack(a, b)
         for _ in range(25):
-            start_time = time.time()
-            valid_actions1 = env1.action_space.all_ground_literals(state1)
-            if verbose:
-                print("Computing valid action spaces without instantiator took {} seconds".format(
-                    time.time() - start_time))
-            start_time = time.time()
-            valid_actions2 = env2.action_space.all_ground_literals(state2)
-            if verbose:
-                print("Computing valid action spaces *with* instantiator took {} seconds".format(
-                    time.time() - start_time))
-            assert valid_actions2.issubset(valid_actions1)
-            action = env2.action_space.sample(state2)
-            state1, _, _, _ = env1.step(action)
-            state2, _, _, _ = env2.step(action)
+            act1 = env.action_space.sample(state1)
+            assert act1.predicate.name == "unstack"
+            assert act1.variables[0].name == "a"
+            assert act1.variables[1].name == "b"
 
-        if verbose:
-            print("Test passed for environment {}.".format(name))
+        env.fix_problem_index(1)
+        state2, _ = env.reset()
+        assert state1.objects == state2.objects
+        # Only one action is possible: unstack(d, c)
+        for _ in range(25):
+            act2 = env.action_space.sample(state2)
+            assert act2.predicate.name == "unstack"
+            assert act2.variables[0].name == "d"
+            assert act2.variables[1].name == "c"
 
-    print("Test passed.")
-
-
-def test_dynamic_action_space_same_obj():
-    """
-    """
-    dir_path = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "pddl")
-
-    name = "dynamic_action_space_same_obj"
-    domain_file = os.path.join(dir_path, "{}.pddl".format(name.lower()))
-    problem_dir = os.path.join(dir_path, name.lower())
-
-    env = PDDLEnv(domain_file, problem_dir,
-        operators_as_actions=True,
-        dynamic_action_space=True,
-    )
-    assert len(env.problems) == 2  # both problems have the same object set
-
-    env.fix_problem_index(0)
-    state1, _ = env.reset()
-    # Only one action is possible: unstack(a, b)
-    for _ in range(25):
-        act1 = env.action_space.sample(state1)
-        assert act1.predicate.name == "unstack"
-        assert act1.variables[0].name == "a"
-        assert act1.variables[1].name == "b"
-
-    env.fix_problem_index(1)
-    state2, _ = env.reset()
-    assert state1.objects == state2.objects
-    # Only one action is possible: unstack(d, c)
-    for _ in range(25):
-        act2 = env.action_space.sample(state2)
-        assert act2.predicate.name == "unstack"
-        assert act2.variables[0].name == "d"
-        assert act2.variables[1].name == "c"
-
-    print("Test passed.")
 
 
 if __name__ == "__main__":
-    test_hierarchical_spaces()
-    # test_dynamic_literal_action_space(verbose=False)
-    test_dynamic_action_space(verbose=False)
-    test_dynamic_action_space_same_obj()
+    unittest.main()

--- a/pddlgym/tests/test_system.py
+++ b/pddlgym/tests/test_system.py
@@ -3,11 +3,15 @@ from pddlgym.demo import run_all
 import gym
 import pddlgym
 
-def test_system():
-    print("WARNING: this test may take around a minute...")
-    run_all(render=False, verbose=False)
-    print("Test passed.")
+import unittest
+
+
+class TestSystem(unittest.TestCase):
+    def test_system(self):
+        print("WARNING: this test may take around a minute...")
+        run_all(render=False, verbose=False)
+        print("Test passed.")
 
 
 if __name__ == '__main__':
-    test_system()
+    unittest.main()


### PR DESCRIPTION
## Description

Make the `core`, `structs`, and `spaces` modules available for import. This allows importing libraries to use the contained classes for type annotations.

Add some (not all) type annotations.

## Tests

Ran each test file in `pddlgym/tests`. They all passed.