### PR TITLE
Expose submodules to importing scripts

### DIFF
--- a/pddlgym/__init__.py
+++ b/pddlgym/__init__.py
@@ -1,6 +1,9 @@
 """Gym environment registration"""
 
 from . import tests
+from . import core
+from . import structs
+from . import spaces
 
 import matplotlib
 # matplotlib.use("Agg")


### PR DESCRIPTION
## Description

Expose `core`, `structs`, or `spaces`, so that a script in another repo could do

```python
from pddlgym import core, structs, spaces
```


## Tests

VSCode stopped complaining about this code in another repo:

```python
import pddlgym

def foo(train_env: pddlgym.core.PDDLEnv):
    pass
```

Once #68 is merged, I'll rebase and run the unittests. Though I don't think they'd catch any bugs this change would introduce. I'm not really sure what bugs this change could introduce, unless one of `core`, `structs`, or `spaces` is already bugged, in which case this would stop us from importing `pddlgym` at all.

Edit: This was split off from #67 