### PR TITLE
Fix corner case handling in _handle_derived_literals

### DIFF
--- a/pddlgym/core.py
+++ b/pddlgym/core.py
@@ -554,11 +554,11 @@ class PDDLEnv(gym.Env):
                 to_remove.add(lit)
         state = state.with_literals(state.literals - to_remove)
 
-        # add negative literals for checking derived predicates
+        # add negative basic literals for checking derived predicates
         state_literals = state.literals
         all_ground_literals = self._observation_space.all_ground_literals(state)
         for lit in all_ground_literals:
-            if lit not in state_literals:
+            if not lit.predicate.is_derived and lit not in state_literals:
                 state_literals = {lit.negative} | state_literals
                 
         while True:  # loop, because derived predicates can be recursive
@@ -567,7 +567,7 @@ class PDDLEnv(gym.Env):
                 if not pred.is_derived:
                     continue
                 assignments = find_satisfying_assignments(
-                    state.literals, pred.body,
+                    state_literals, pred.body,
                     type_to_parent_types=self.domain.type_to_parent_types,
                     constants=self.domain.constants,
                     mode="prolog",
@@ -579,6 +579,9 @@ class PDDLEnv(gym.Env):
                     if derived_literal not in state.literals:
                         new_derived_literals.add(derived_literal)
             if new_derived_literals:
+                # update state_literals for recursive checking
+                state_literals = state_literals | new_derived_literals
+                # save derived literals in state
                 state = state.with_literals(state.literals | new_derived_literals)
             else:  # terminate
                 break

--- a/pddlgym/core.py
+++ b/pddlgym/core.py
@@ -553,6 +553,14 @@ class PDDLEnv(gym.Env):
             if lit.predicate.is_derived:
                 to_remove.add(lit)
         state = state.with_literals(state.literals - to_remove)
+
+        # add negative literals for checking derived predicates
+        state_literals = state.literals
+        all_ground_literals = self._observation_space.all_ground_literals(state)
+        for lit in all_ground_literals:
+            if lit not in state_literals:
+                state_literals = {lit.negative} | state_literals
+                
         while True:  # loop, because derived predicates can be recursive
             new_derived_literals = set()
             for pred in self.domain.predicates.values():

--- a/pddlgym/prolog_interface.py
+++ b/pddlgym/prolog_interface.py
@@ -161,7 +161,7 @@ class PrologInterface:
         """
         """
         kb_str = ""
-        for lit in sorted(kb):
+        for lit in sorted(kb, key=lambda l:l.predicate.name):
             pred_name = cls._clean_predicate_name(lit.predicate.name)
             atoms = ",".join([cls._clean_atom_name(a) for a in lit.variables])
             kb_str += "\n{}({}).".format(pred_name, atoms)

--- a/pddlgym/prolog_interface.py
+++ b/pddlgym/prolog_interface.py
@@ -161,7 +161,7 @@ class PrologInterface:
         """
         """
         kb_str = ""
-        for lit in sorted(kb, key=lambda l:l.predicate.name):
+        for lit in sorted(kb, key=lambda l: l.predicate.name):
             pred_name = cls._clean_predicate_name(lit.predicate.name)
             atoms = ",".join([cls._clean_atom_name(a) for a in lit.variables])
             kb_str += "\n{}({}).".format(pred_name, atoms)
@@ -247,7 +247,7 @@ class PrologInterface:
             objects_of_type = self._type_to_atomnames[var_type]
             objects_str = "[" + ",".join(objects_of_type) + "]"
             pred_str_body = self._prolog_goal_line(lit.body)
-            pred_str = "forall(member({}, {}), {})".format(variable, objects_str, pred_str_body)
+            pred_str = "foreach(member({}, {}), {})".format(variable, objects_str, pred_str_body)
             return pred_str
         if isinstance(lit, Exists):
             variables = ",".join([self._clean_variable_name(a.name)

--- a/pddlgym/tests/pddl/derivedblocks.pddl
+++ b/pddlgym/tests/pddl/derivedblocks.pddl
@@ -1,0 +1,70 @@
+
+(define (domain derivedblocks)
+  (:requirements :typing)
+  (:types loc obj robot)
+  
+  (:predicates (on_loc ?v0 - obj ?v1 - loc)
+	(on_obj ?v0 - obj ?v1 - obj)
+	(in_gripper ?v0 - obj ?v1 - robot)
+	(obj_clear ?v0 - obj)
+	(gripper_empty ?v0 - robot)
+	(pick ?v0 - obj)
+	(place ?v0 - loc)
+	(stack ?v0 - obj)
+  )
+  ; (:actions stack pick place)
+
+  
+
+	(:action pick_from_loc
+		:parameters (?o1 - obj ?l - loc ?r - robot)
+		:precondition (and (pick ?o1)
+			(gripper_empty ?r)
+			(obj_clear ?o1)
+			(on_loc ?o1 ?l))
+		:effect (and
+			(in_gripper ?o1 ?r)
+			(not (on_loc ?o1 ?l)))
+	)
+	
+
+	(:action place_on_loc
+		:parameters (?o1 - obj ?l - loc ?r - robot)
+		:precondition (and (place ?l)
+			(in_gripper ?o1 ?r))
+		:effect (and
+			(not (in_gripper ?o1 ?r))
+			(on_loc ?o1 ?l))
+	)
+	
+
+	(:action unstack
+		:parameters (?o1 - obj ?o2 - obj ?r - robot)
+		:precondition (and (pick ?o1)
+			(gripper_empty ?r)
+			(obj_clear ?o1)
+			(on_obj ?o1 ?o2))
+		:effect (and
+			(in_gripper ?o1 ?r)
+			(not (on_obj ?o1 ?o2)))
+	)
+	
+
+	(:action stack
+		:parameters (?o1 - obj ?o2 - obj ?r - robot)
+		:precondition (and (stack ?o2)
+			(in_gripper ?o1 ?r)
+			(obj_clear ?o2))
+		:effect (and
+			(not (in_gripper ?o1 ?r))
+			(on_obj ?o1 ?o2))
+	)
+
+  (:derived (obj_clear ?v_1) (forall (?o - obj) (not (on_obj ?o ?v_1))))
+
+(:derived (gripper_empty ?v_1) (forall (?o - obj) (not (in_gripper ?o ?v_1))))
+
+
+
+)
+        

--- a/pddlgym/tests/pddl/derivedblocks/test_problem.pddl
+++ b/pddlgym/tests/pddl/derivedblocks/test_problem.pddl
@@ -1,0 +1,16 @@
+
+(define (problem prob) (:domain derivedblocks)
+  (:objects
+        block1 - obj
+	block2 - obj
+	gripper - robot
+	table - loc
+  )
+  (:goal (and
+	(gripper_empty gripper)
+	(on_loc block1 table)
+	(on_obj block2 block1)))
+  (:init 
+	(on_loc block2 table)
+	(on_obj block1 block2)
+))


### PR DESCRIPTION
## Descirption
Derived literals are dynamically produced based on basic literals.In the previous implementation, when all basic literals related to certain entity are negative, the derived literals related to this entity can not be handled.

## Solution
Step 1. In "core.py", add all negative literals before checking derived predicates.
Step 2. Since the input to prolog contains both positive and negative literals, change the way how kb literals are ordered to avoid prolog warning "Clauses of xxx are not together in the source-file".
