### PR TITLE
add visit_all domain, problems and render

### DIFF
--- a/pddlgym/__init__.py
+++ b/pddlgym/__init__.py
@@ -166,6 +166,9 @@ for env_name, kwargs in [
         ("navigation8", { 'render': lambda obs: navigation_render(obs, make("PDDLEnvNavigation8-v0").domain) }),
         ("navigation9", { 'render': lambda obs: navigation_render(obs, make("PDDLEnvNavigation9-v0").domain) }),
         ("navigation10", { 'render': lambda obs: navigation_render(obs, make("PDDLEnvNavigation10-v0").domain) }),
+        ("visit_all", {'render' : visit_all_render,
+                       'operators_as_actions': True,
+                       'dynamic_action_space': True}),
 ]:
     other_args = {
         "raise_error_on_invalid_action": False,

--- a/pddlgym/pddl/visit_all.pddl
+++ b/pddlgym/pddl/visit_all.pddl
@@ -1,0 +1,22 @@
+(define (domain visit_all)
+    (:requirements :typing)
+    (:types        place - object)
+    (:predicates
+        (connected ?x - place ?y - place)
+	    (at-robot ?x - place)
+	    (visited ?x - place)
+    )
+
+    (:action move
+        :parameters (?curpos - place ?nextpos - place)
+        :precondition (and
+            (at-robot ?curpos)
+            (connected ?curpos ?nextpos)
+        )
+        :effect (and
+            (at-robot ?nextpos)
+            (not (at-robot ?curpos))
+            (visited ?nextpos)
+        )
+    )
+)

--- a/pddlgym/pddl/visit_all/p01.pddl
+++ b/pddlgym/pddl/visit_all/p01.pddl
@@ -1,0 +1,56 @@
+;; equivalent to:
+;; https://github.com/aibasel/downward-benchmarks/blob/master/visitall-opt11-strips/problem03-half.pddl
+;; only domain name change and object types were made explicit
+(define (problem grid-3)
+(:domain visit_all)
+(:objects
+	loc-x0-y0 - place
+	loc-x0-y1 - place
+	loc-x0-y2 - place
+	loc-x1-y0 - place
+	loc-x1-y1 - place
+	loc-x1-y2 - place
+	loc-x2-y0 - place
+	loc-x2-y1 - place
+	loc-x2-y2 - place
+
+)
+(:init
+	(at-robot loc-x1-y1)
+	(visited loc-x1-y1)
+	(connected loc-x0-y0 loc-x1-y0)
+ 	(connected loc-x0-y0 loc-x0-y1)
+ 	(connected loc-x0-y1 loc-x1-y1)
+ 	(connected loc-x0-y1 loc-x0-y0)
+ 	(connected loc-x0-y1 loc-x0-y2)
+ 	(connected loc-x0-y2 loc-x1-y2)
+ 	(connected loc-x0-y2 loc-x0-y1)
+ 	(connected loc-x1-y0 loc-x0-y0)
+ 	(connected loc-x1-y0 loc-x2-y0)
+ 	(connected loc-x1-y0 loc-x1-y1)
+ 	(connected loc-x1-y1 loc-x0-y1)
+ 	(connected loc-x1-y1 loc-x2-y1)
+ 	(connected loc-x1-y1 loc-x1-y0)
+ 	(connected loc-x1-y1 loc-x1-y2)
+ 	(connected loc-x1-y2 loc-x0-y2)
+ 	(connected loc-x1-y2 loc-x2-y2)
+ 	(connected loc-x1-y2 loc-x1-y1)
+ 	(connected loc-x2-y0 loc-x1-y0)
+ 	(connected loc-x2-y0 loc-x2-y1)
+ 	(connected loc-x2-y1 loc-x1-y1)
+ 	(connected loc-x2-y1 loc-x2-y0)
+ 	(connected loc-x2-y1 loc-x2-y2)
+ 	(connected loc-x2-y2 loc-x1-y2)
+ 	(connected loc-x2-y2 loc-x2-y1)
+
+)
+(:goal
+(and
+	(visited loc-x0-y0)
+	(visited loc-x0-y2)
+	(visited loc-x1-y1)
+	(visited loc-x2-y0)
+	(visited loc-x2-y1)
+)
+)
+)

--- a/pddlgym/pddl/visit_all/p02.pddl
+++ b/pddlgym/pddl/visit_all/p02.pddl
@@ -1,0 +1,91 @@
+;; equivalent to:
+;; https://github.com/aibasel/downward-benchmarks/blob/master/visitall-opt11-strips/problem04-half.pddl
+;; only domain name change and object types were made explicit
+(define (problem grid-4)
+(:domain visit_all)
+(:objects
+	loc-x0-y0 - place
+	loc-x0-y1 - place
+	loc-x0-y2 - place
+	loc-x0-y3 - place
+	loc-x1-y0 - place
+	loc-x1-y1 - place
+	loc-x1-y2 - place
+	loc-x1-y3 - place
+	loc-x2-y0 - place
+	loc-x2-y1 - place
+	loc-x2-y2 - place
+	loc-x2-y3 - place
+	loc-x3-y0 - place
+	loc-x3-y1 - place
+	loc-x3-y2 - place
+	loc-x3-y3 - place
+
+
+)
+(:init
+	(at-robot loc-x2-y2)
+	(visited loc-x2-y2)
+	(connected loc-x0-y0 loc-x1-y0)
+ 	(connected loc-x0-y0 loc-x0-y1)
+ 	(connected loc-x0-y1 loc-x1-y1)
+ 	(connected loc-x0-y1 loc-x0-y0)
+ 	(connected loc-x0-y1 loc-x0-y2)
+ 	(connected loc-x0-y2 loc-x1-y2)
+ 	(connected loc-x0-y2 loc-x0-y1)
+ 	(connected loc-x0-y2 loc-x0-y3)
+ 	(connected loc-x0-y3 loc-x1-y3)
+ 	(connected loc-x0-y3 loc-x0-y2)
+ 	(connected loc-x1-y0 loc-x0-y0)
+ 	(connected loc-x1-y0 loc-x2-y0)
+ 	(connected loc-x1-y0 loc-x1-y1)
+ 	(connected loc-x1-y1 loc-x0-y1)
+ 	(connected loc-x1-y1 loc-x2-y1)
+ 	(connected loc-x1-y1 loc-x1-y0)
+ 	(connected loc-x1-y1 loc-x1-y2)
+ 	(connected loc-x1-y2 loc-x0-y2)
+ 	(connected loc-x1-y2 loc-x2-y2)
+ 	(connected loc-x1-y2 loc-x1-y1)
+ 	(connected loc-x1-y2 loc-x1-y3)
+ 	(connected loc-x1-y3 loc-x0-y3)
+ 	(connected loc-x1-y3 loc-x2-y3)
+ 	(connected loc-x1-y3 loc-x1-y2)
+ 	(connected loc-x2-y0 loc-x1-y0)
+ 	(connected loc-x2-y0 loc-x3-y0)
+ 	(connected loc-x2-y0 loc-x2-y1)
+ 	(connected loc-x2-y1 loc-x1-y1)
+ 	(connected loc-x2-y1 loc-x3-y1)
+ 	(connected loc-x2-y1 loc-x2-y0)
+ 	(connected loc-x2-y1 loc-x2-y2)
+ 	(connected loc-x2-y2 loc-x1-y2)
+ 	(connected loc-x2-y2 loc-x3-y2)
+ 	(connected loc-x2-y2 loc-x2-y1)
+ 	(connected loc-x2-y2 loc-x2-y3)
+ 	(connected loc-x2-y3 loc-x1-y3)
+ 	(connected loc-x2-y3 loc-x3-y3)
+ 	(connected loc-x2-y3 loc-x2-y2)
+ 	(connected loc-x3-y0 loc-x2-y0)
+ 	(connected loc-x3-y0 loc-x3-y1)
+ 	(connected loc-x3-y1 loc-x2-y1)
+ 	(connected loc-x3-y1 loc-x3-y0)
+ 	(connected loc-x3-y1 loc-x3-y2)
+ 	(connected loc-x3-y2 loc-x2-y2)
+ 	(connected loc-x3-y2 loc-x3-y1)
+ 	(connected loc-x3-y2 loc-x3-y3)
+ 	(connected loc-x3-y3 loc-x2-y3)
+ 	(connected loc-x3-y3 loc-x3-y2)
+
+)
+(:goal
+(and
+	(visited loc-x0-y0)
+	(visited loc-x0-y1)
+	(visited loc-x0-y3)
+	(visited loc-x1-y0)
+	(visited loc-x2-y2)
+	(visited loc-x3-y0)
+	(visited loc-x3-y2)
+	(visited loc-x3-y3)
+)
+)
+)

--- a/pddlgym/rendering/__init__.py
+++ b/pddlgym/rendering/__init__.py
@@ -17,3 +17,4 @@ from .sar_render_from_string_grid import sar_render_from_string_grid
 from .hiking import render as hiking_render
 from .maze import render as maze_render
 from .navigation import render as navigation_render
+from .visit_all import render as visit_all_render

--- a/pddlgym/rendering/visit_all.py
+++ b/pddlgym/rendering/visit_all.py
@@ -70,19 +70,6 @@ def get_token_images(obs_cell):
     return [TOKEN_IMAGES[obs_cell]]
 
 def render(obs, mode='human', close=False):
-    if mode == "egocentric":
-        layout = build_layout_egocentric(obs)
-        return render_from_layout(layout, get_token_images)
-    elif mode == "human":
+    if mode == "human":
         layout = build_layout(obs)
         return render_from_layout(layout, get_token_images)
-    elif mode == "egocentric_crisp":
-        layout = build_layout_egocentric(obs)
-        return render_from_layout_crisp(layout, get_token_images)
-    elif mode == "human_crisp":
-        layout = build_layout(obs)
-        return render_from_layout_crisp(layout, get_token_images)
-    elif mode == "layout":
-        return build_layout(obs)
-    elif mode == "egocentric_layout":
-        return build_layout_egocentric(obs)

--- a/pddlgym/rendering/visit_all.py
+++ b/pddlgym/rendering/visit_all.py
@@ -1,0 +1,88 @@
+from .utils import get_asset_path, render_from_layout
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+NUM_OBJECTS = 3
+ROBOT, LOCATION, TO_VISIT = range(NUM_OBJECTS)
+
+TOKEN_IMAGES = {
+    ROBOT : plt.imread(get_asset_path('sokoban_player.png')),
+    LOCATION: plt.imread(get_asset_path('sokoban_clear.png')),
+    TO_VISIT: plt.imread(get_asset_path('sokoban_goal.png')),
+}
+
+def get_robot_locations(obs):
+    locs = []
+    for lit in obs:
+        if lit.predicate.name == 'at-robot':
+            locs.append(loc_str_to_loc(lit.variables[0]))
+    return locs
+
+def get_values(obs, name):
+    values = []
+    for lit in obs:
+        if lit.predicate.name == name:
+            values.append(lit.variables)
+    return values
+def loc_str_to_loc(loc_str):
+    _, r, c = loc_str.split('-')
+    return (int(r[1::]), int(c[1::]))
+
+def build_layout(obs):
+    # Get location boundaries
+    max_r, max_c = -np.inf, -np.inf # r - row; c - collumn
+    for lit in obs:
+        for v in lit.variables:
+            if v.startswith('loc-'):
+                r, c = loc_str_to_loc(v)
+                max_r = max(max_r, r)
+                max_c = max(max_c, c)
+    layout = TO_VISIT * np.ones((max_r+1, max_c+1), dtype=np.uint8)
+
+
+    # Put things in the layout
+    # Also track visited locs
+    visited_locs = set()
+
+    for v in get_values(obs, 'visited'):
+        r, c = loc_str_to_loc(v[0])
+        layout[r, c] = LOCATION
+        visited_locs.add((r, c))
+
+    for r, c in get_robot_locations(obs) :
+        layout[r, c] = ROBOT
+        visited_locs.add((r, c))
+
+    # 1 indexing
+    # layout = layout[1:, 1:]
+
+    # r-c flip
+    layout = np.transpose(layout)
+
+    # print("layout:", layout)
+    # import ipdb; ipdb.set_trace()
+    return layout
+
+
+def get_token_images(obs_cell):
+    return [TOKEN_IMAGES[obs_cell]]
+
+def render(obs, mode='human', close=False):
+    if mode == "egocentric":
+        layout = build_layout_egocentric(obs)
+        return render_from_layout(layout, get_token_images)
+    elif mode == "human":
+        layout = build_layout(obs)
+        return render_from_layout(layout, get_token_images)
+    elif mode == "egocentric_crisp":
+        layout = build_layout_egocentric(obs)
+        return render_from_layout_crisp(layout, get_token_images)
+    elif mode == "human_crisp":
+        layout = build_layout(obs)
+        return render_from_layout_crisp(layout, get_token_images)
+    elif mode == "layout":
+        return build_layout(obs)
+    elif mode == "egocentric_layout":
+        return build_layout_egocentric(obs)


### PR DESCRIPTION
The domain visit_all is in a certain sense similar to sokoban.
Both have an agent that moves in a 2D grid.
The rendering is therefore very similar to sokoban and uses the same assets.
The circle indicating a goal location for sokoban is used to indicate a location that is not visited so far. This looks like the agent is collecting these circles.

Contrary to the name, the agent does not have to visit all locations in each task. (there are two kinds problemXY-full and problemXY-half. Here are only examples of the half-kind)
It would be nice to color the mandatory locations/circles different but it was not apparent to me how this would be done without major changes in the architecture of render (the observation does not see the goal description) or on the pddl level.
