### PR TITLE
Fix passive warnings

### DIFF
--- a/pddlgym/core.py
+++ b/pddlgym/core.py
@@ -15,13 +15,11 @@ Usage example:
 >>> action = env.action_space.sample()
 >>> obs, reward, done, debug_info = env.step(action)
 """
-from pddlgym.parser import PDDLDomainParser, PDDLProblemParser, PDDLParser
+from pddlgym.parser import PDDLDomainParser, PDDLProblemParser
 from pddlgym.inference import find_satisfying_assignments, check_goal
 from pddlgym.structs import ground_literal, Literal, State, ProbabilisticEffect, LiteralConjunction, NoChange
 from pddlgym.spaces import LiteralSpace, LiteralSetSpace, LiteralActionSpace
 
-import copy
-import functools
 import glob
 import os
 from itertools import product
@@ -417,7 +415,7 @@ class PDDLEnv(gym.Env):
         self._problem_idx = problem_idx
         self._problem_index_fixed = True
 
-    def reset(self):
+    def reset(self, seed=None, options=None):
         """
         Set up a new PDDL problem and start a new episode.
 
@@ -430,6 +428,9 @@ class PDDLEnv(gym.Env):
         debug_info : dict
             See self._get_debug_info()
         """
+        if seed is not None:
+            self.seed(seed)
+
         if not self._problem_index_fixed:
             self._problem_idx = self.rng.choice(len(self.problems))
         self._problem = self.problems[self._problem_idx]
@@ -480,12 +481,14 @@ class PDDLEnv(gym.Env):
             1 if the goal is reached and 0 otherwise.
         done : bool
             True if the goal is reached.
+        truncated : bool 
+            Whether a truncation condition outside the scope of the MDP is satisfied. This never happens, so set to False.
         debug_info : dict
             See self._get_debug_info.
         """
         state, reward, done, debug_info = self.sample_transition(action)
         self.set_state(state)
-        return state, reward, done, debug_info
+        return state, reward, done, False, debug_info
 
     def _get_new_state_info(self, state):
         state = self._handle_derived_literals(state)

--- a/pddlgym/custom/searchandrescue.py
+++ b/pddlgym/custom/searchandrescue.py
@@ -344,9 +344,9 @@ class SearchAndRescueEnv(PDDLSearchAndRescueEnv):
         return self._internal_to_state(internal_state), debug_info
 
     def step(self, action):
-        internal_state, reward, done, debug_info = super().step(action)
+        internal_state, reward, done, truncated, debug_info = super().step(action)
         state = self._internal_to_state(internal_state)
-        return state, reward, done, debug_info
+        return state, reward, done, truncated, debug_info
 
     def get_successor_state(self, state, action):
         internal_state = self._state_to_internal(state)

--- a/pddlgym/prolog_interface.py
+++ b/pddlgym/prolog_interface.py
@@ -1,4 +1,4 @@
-from pddlgym.structs import Predicate, Literal, LiteralConjunction, LiteralDisjunction, ForAll, Exists, Not
+from pddlgym.structs import Predicate, Literal, LiteralConjunction, LiteralDisjunction, ForAll, Exists
 from pddlgym.utils import get_object_combinations
 import random
 from collections import defaultdict

--- a/pddlgym/spaces.py
+++ b/pddlgym/spaces.py
@@ -4,7 +4,7 @@ Unlike typical spaces, Literal spaces may change with
 each episode, since objects, and therefore possible
 groundings, may change with each new PDDL problem.
 """
-from pddlgym.structs import LiteralConjunction, Literal, ground_literal
+from pddlgym.structs import LiteralConjunction, Literal, ground_literal, State
 from pddlgym.parser import PDDLProblemParser
 from pddlgym.downward_translate.instantiate import explore as downward_explore
 from pddlgym.downward_translate.pddl_parser import open as downward_open
@@ -88,6 +88,26 @@ class LiteralSpace(Space):
                 lit = predicate(*choice)
                 all_ground_literals.add(lit)
         return all_ground_literals
+
+    def contains(self, x):
+        """Return boolean if x is a valid member of this space."""
+        if not isinstance(x, State):
+            return False
+
+        # Check all predicates can be grounded from the objects in the state.
+        try:
+            # If the state contains object types not defined in the environment, a KeyError is raised.
+            self._update_objects_from_state(x)
+        except KeyError:
+            return False
+
+        # Check all state and goal literals are valid.
+        for lit in (x.literals | set(x.goal.literals)):
+            if lit not in self._all_ground_literals:
+                return False
+
+        return True
+
 
 
 class LiteralActionSpace(LiteralSpace):

--- a/pddlgym/tests/test_pddlenv.py
+++ b/pddlgym/tests/test_pddlenv.py
@@ -43,7 +43,7 @@ class TestPDDLEnv(unittest.TestCase):
         # Valid args
         action = action_pred('b2')
 
-        obs, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(action)
 
         assert obs.literals == frozenset({ pred1('b2'), pred3('b2', 'd1', 'c1'), 
             pred3('a1', 'c1', 'd1'), pred3('a2', 'c2', 'd2') })
@@ -85,7 +85,7 @@ class TestPDDLEnv(unittest.TestCase):
             isfurry(nomsy),
         })
 
-        obs, _, _, _ = env.step(pet('block1'))
+        obs, _, _, _, _ = env.step(pet('block1'))
 
         assert obs.literals == frozenset({
             ispresent(nomsy),
@@ -99,7 +99,7 @@ class TestPDDLEnv(unittest.TestCase):
             isfurry(nomsy),
         })
 
-        obs, _, _, _ = env.step(pet(nomsy))
+        obs, _, _, _, _ = env.step(pet(nomsy))
 
         assert obs.literals == frozenset({
             ispresent(nomsy),

--- a/pddlgym/tests/test_spaces.py
+++ b/pddlgym/tests/test_spaces.py
@@ -112,8 +112,8 @@ class TestSpaces(unittest.TestCase):
                         time.time() - start_time))
                 assert valid_actions2.issubset(valid_actions1)
                 action = env2.action_space.sample(state2)
-                state1, _, _, _ = env1.step(action)
-                state2, _, _, _ = env2.step(action)
+                state1, _, _, _, _ = env1.step(action)
+                state2, _, _, _, _ = env2.step(action)
 
             if verbose:
                 print("Test passed for environment {}.".format(name))

--- a/pddlgym/utils.py
+++ b/pddlgym/utils.py
@@ -57,7 +57,7 @@ def run_demo(env, policy, max_num_steps=10, render=False,
         if verbose:
             print("Act:", action)
 
-        obs, reward, done, _ = env.step(action)
+        obs, reward, done, _, _ = env.step(action)
         env.render()
         if verbose:
             print("Rew:", reward)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pddlgym',
-      version='0.0.5',
+      version='0.0.6',
       install_requires=['matplotlib', 'pillow', 'gym', 'imageio', 'scikit-image'],
       packages=find_packages(),
       include_package_data=True,


### PR DESCRIPTION
When using PDDLEnv and LiteralSpace, these warnings keep popping up. These changes fix the warnings from the passive checker.

Warnings removed:

	- gym/utils/passive_env_checker.py:187: UserWarning: WARN: Future gym versions will require that `Env.reset` can be passed `options` to allow the environment initialisation to be passed additional information.
	- gym/utils/passive_env_checker.py:167: UserWarning: WARN: The obs returned by the `step()` method is not within the observation space
	- gym/utils/passive_env_checker.py:219: DeprecationWarning: WARN: Core environment is written in old step API which returns one bool instead of two. It is recommended to rewrite the environment with new step API.