### PR TITLE
add type checking to Operator printing

### DIFF
--- a/pddlgym/parser.py
+++ b/pddlgym/parser.py
@@ -44,9 +44,15 @@ class Operator:
 
     def __str__(self):
         s = self.name + "(" + ",".join(map(str, self.params)) + "): "
-        s += " & ".join(map(str, self.preconds.literals))
+        if isinstance(self.preconds, Literal):
+            s += str(self.preconds)
+        else:
+            s += " & ".join(map(str, self.preconds.literals))
         s += " => "
-        s += " & ".join(map(str, self.effects.literals))
+        if isinstance(self.effects, Literal):
+            s += str(self.effects)
+        else:
+            s += " & ".join(map(str, self.effects.literals))
         return s
 
     def pddl_str(self):


### PR DESCRIPTION
This is a fix to #95. I implemented type checking in the `Operator` class `__str__` method, which solves this problem.